### PR TITLE
Instead of requiring a --builder-prefix, why not just find ourselves?

### DIFF
--- a/bin/nubis-builder
+++ b/bin/nubis-builder
@@ -317,7 +317,7 @@ build(){
    fi
 
    if [[ ! "$project_path" ]]; then
-      usage "--builder-prefix is a required parameter"
+      usage "--project-path is a required parameter"
    fi
 
    # We have our own tooling in $builder_prefix/bin, and if the project has their own build tools let's make them available

--- a/bin/nubis-builder
+++ b/bin/nubis-builder
@@ -313,7 +313,9 @@ build(){
    done
 
    if [[ ! "$builder_prefix" ]]; then
-      usage "--builder-prefix is a required parameter"
+      # Find ourselves
+      bin_dir=`dirname $0`
+      builder_prefix=`cd $bin_dir/..; pwd`
    fi
 
    if [[ ! "$project_path" ]]; then


### PR DESCRIPTION
Might need a bit of polishing, but this works for me