### PR TITLE
Refactoring AMI generation & adding builder verbosity

### DIFF
--- a/bin/aws-find-ami
+++ b/bin/aws-find-ami
@@ -171,3 +171,7 @@ cat << EOF >> $output_file
 }
 
 EOF
+
+# Share what AMI name and description we're building against
+project_name=$(jq --raw-output '"\(.variables.project_name)"' < $build_file)
+echo "${project_name}: Builder ${json_key_prefix} is using ${aws_ami_name} (${aws_ami_id})"

--- a/bin/aws-find-ami
+++ b/bin/aws-find-ami
@@ -4,7 +4,7 @@ if [[ $# -lt 1 ]]; then
    echo "This tool searches the Amazon AMI registry, sorts the results, and returns a single AMI ID"
    echo "that corresponds to the most recent image as determined by jq sort."
    echo
-   echo "Usage: $0 --build-file <build file> --owners <owners> --region <aws region> [--<filter name> <value>] [--<filter name> <value>] [<...>]"
+   echo "Usage: $0 --build-file <build file> --output-file <generated json> --owners <owners> --region <aws region> [--<filter name> <value>] [--<filter name> <value>] [<...>]"
    echo
    echo "Underlying AWS CLI documentation:"
    echo "http://docs.aws.amazon.com/cli/latest/reference/ec2/describe-images.html"
@@ -62,13 +62,24 @@ while [[ "$1" ]]; do
          fi
          shift
          ;;
+      --output-file)
+         if [[ -w $2 ]]; then
+            output_file=$2
+         else
+            fail "Output file $2 is unwritable"
+         fi
+         shift
+         ;;
       --*)
-         aws_filters="$aws_filters Name=${1:2},Values=$2"
+         if [[ "$2" ]]; then
+            aws_filters="$aws_filters Name=${1:2},Values=$2"
+         else
+            fail "missing parameter for $1"
+         fi
          shift
          ;;
       *)
-         echo "Invalid parameter passed \"$1\""
-         exit 1
+         fail "Invalid parameter passed \"$1\""
          ;;
     esac
     shift
@@ -84,6 +95,10 @@ fi
 
 if [[ ! "$build_file" ]]; then
    fail "The parameter --build-file is required."
+fi
+
+if [[ ! "$output_file" ]]; then
+   fail "The parameter --output-file is required."
 fi
 
 # Grab access aws_secret_access_key from the build file
@@ -112,17 +127,47 @@ source_ami_project_name=$(jq --raw-output '"\(.variables.source_ami_project_name
 if [[ "$source_ami_project_name" == "base" ]]; then
    # Sort base on image name
    aws_ami_id=$(echo "$aws_ami_description" | jq --raw-output '[.Images[] | {Name, ImageId}] | sort_by(.Name) | .[length-1] | .ImageId')
+   aws_ami_name=$(echo "$aws_ami_description" | jq --raw-output ".Images[] | {Name, ImageId} | select(.ImageId==\"${aws_ami_id}\") | .Name")
+
+   # I wish Amazon had a platform tag..
+   case $aws_ami_name in
+      ubuntu/*)
+         aws_ami_platform="ubuntu"
+         ;;
+      amzn-ami-*)
+         aws_ami_platform="amazon-linux"
+         ;;
+      *)
+         fail "can't parse platform for ami id ${aws_ami_id}"
+         aws_ami_platform="unknown"
+         ;;
+   esac
 else
-   # Sort on nubis AMI specific tags
+   # Get data based on nubis specific tags
    aws_ami_id=$(echo "$aws_ami_description" | jq --raw-output '[.Images[] | {id: .ImageId, version: .Tags[] | select(.Key == "version") | .Value}] | sort_by(.version | split(".") | map(tonumber)) | .[length-1] | .id')
+   aws_ami_name=$(echo "$aws_ami_description" | jq --raw-output ".Images[] | {Name, ImageId} | select(.ImageId==\"${aws_ami_id}\") | .Name")
+   aws_ami_platform=$(echo "$aws_ami_description" | jq --raw-output "[.Images[] | {ImageId, Tags}][] | select(.ImageId==\"${aws_ami_id}\") | [.Tags[] | select(.Key==\"platform\")][] | .Value")
+   if [[ ! "$aws_ami_platform" ]]; then
+      fail "ami id ${aws_ami_id} missing platform tag, aborting"
+   fi
 fi
+
+aws_ami_rootdevicetype=$(echo "$aws_ami_description" | jq --raw-output ".Images[] | {RootDeviceType, ImageId} | select(.ImageId==\"${aws_ami_id}\") | .RootDeviceType")
 
 # Clean up temporary config file
 rm -f $aws_config
 
-# Print the results
-if [[ "$aws_ami_id" ]]; then
-   echo $aws_ami_id
-else
-   echo "No results"
-fi
+# Save results
+json_key_prefix="aws_${aws_ami_platform/-/_}_${aws_ami_rootdevicetype/-/_}"
+
+cat << EOF >> $output_file
+{
+  "variables": {
+    "${json_key_prefix}_ami": "$aws_ami_id",
+    "${json_key_prefix}_name": "$aws_ami_name",
+    "${json_key_prefix}_platform": "$aws_ami_platform",
+    "${json_key_prefix}_rootdevicetype": "$aws_ami_rootdevicetype"
+  }
+}
+
+EOF

--- a/bin/generate-base-ami-ids
+++ b/bin/generate-base-ami-ids
@@ -67,51 +67,69 @@ if [[ "${aws_region:-null}" == "null" ]]; then
    fail "Region not specified in $build_file, exiting"
 fi
 
-# Search for latest official Canonical Ubuntu Trusty EBS AMI
-aws_ubuntu_ebs_ami=$(aws-find-ami --build-file $build_file \
-                     --owners 099720109477 \
-                     --region $aws_region \
-                     --virtualization-type hvm \
-                     --root-device-type ebs \
-                     --architecture x86_64 \
-                     --block-device-mapping.volume-type gp2 \
-                     --name 'ubuntu/images/hvm-ssd/ubuntu-trusty-14.04*')
+for builders in $(jq --raw-output '.builders[] | "\(.type)@\([.tags | .platform][])"' < $build_file); do
+   type=${builders%@*}
+   platform=${builders#*@}
 
-# Search for latest official Amazon Linux EBS AMI
-aws_amazon_linux_ebs_ami=$(aws-find-ami --build-file $build_file \
-                           --owners amazon \
-                           --region $aws_region \
-                           --virtualization-type hvm \
-                           --root-device-type ebs \
-                           --architecture x86_64 \
-                           --block-device-mapping.volume-type gp2 \
-                           --name 'amzn-ami-hvm-*')
-
-# Search for official Canonical Ubuntu Trusty instance-store AMI
-aws_ubuntu_instance_ami=$(aws-find-ami --build-file $build_file \
-                          --owners 099720109477 \
-                          --region $aws_region \
-                          --virtualization-type hvm \
-                          --root-device-type instance-store \
-                          --architecture x86_64 \
-                          --name 'ubuntu/images/hvm-instance/ubuntu-trusty-14.04*')
-
-# Search for latest official Amazon Linux instance-store AMI
-aws_amazon_linux_instance_ami=$(aws-find-ami --build-file $build_file \
-                                --owners amazon \
-                                --region $aws_region \
-                                --virtualization-type hvm \
-                                --root-device-type instance-store \
-                                --architecture x86_64 \
-                                --name 'amzn-ami-hvm-*')
-
-cat << EOF > $output_file
-{
-  "variables": {
-    "aws_amazon_linux_ebs_ami": "${aws_amazon_linux_ebs_ami:-null}",
-    "aws_amazon_linux_instance_ami": "${aws_amazon_linux_instance_ami:-null}",
-    "aws_ubuntu_ebs_ami": "${aws_ubuntu_ebs_ami:-null}",
-    "aws_ubuntu_instance_ami": "${aws_ubuntu_instance_ami:-null}"
-  }
-}
-EOF
+   case $type in
+      amazon-ebs)
+         case $platform in
+            ubuntu)
+               aws-find-ami --build-file $build_file \
+                            --output-file $output_file \
+                            --owners 099720109477 \
+                            --region $aws_region \
+                            --virtualization-type hvm \
+                            --root-device-type ebs \
+                            --block-device-mapping.volume-type gp2 \
+                            --architecture x86_64 \
+                            --name 'ubuntu/images/hvm-ssd/ubuntu-trusty-14.04*' || fail "unable to find base ami for $platform on $type"
+               ;;
+            amazon-linux)
+               aws-find-ami --build-file $build_file \
+                            --output-file $output_file \
+                            --owners amazon \
+                            --region $aws_region \
+                            --virtualization-type hvm \
+                            --root-device-type ebs \
+                            --block-device-mapping.volume-type gp2 \
+                            --architecture x86_64 \
+                            --name 'amzn-ami-hvm-*' || fail "unable to find base ami for $platform on $type"
+               ;;
+            *)
+               fail "unknown platform type $platform"
+               ;;
+         esac
+         ;;
+      instance-store)
+         case $platform in
+            ubuntu)
+               aws-find-ami --build-file $build_file \
+                            --output-file $output_file \
+                            --owners 099720109477 \
+                            --region $aws_region \
+                            --virtualization-type hvm \
+                            --root-device-type instance-store \
+                            --architecture x86_64 \
+                            --name 'ubuntu/images/hvm-ssd/ubuntu-trusty-14.04*' || fail "unable to find base ami for $platform on $type"
+               ;;
+            amazon-linux)
+               aws-find-ami --build-file $build_file \
+                            --output-file $output_file \
+                            --owners amazon \
+                            --region $aws_region \
+                            --virtualization-type hvm \
+                            --root-device-type instance-store \
+                            --architecture x86_64 \
+                            --name 'amzn-ami-hvm-*' || fail "unable to find base ami for $platform on $type"
+               ;;
+            *)
+               fail "unknown platform type $platform"
+               ;;
+         esac
+         ;;
+      *)
+         fail "unknown builder type $type"
+         ;;
+   esac
+done

--- a/bin/generate-source-ami-ids
+++ b/bin/generate-source-ami-ids
@@ -81,69 +81,36 @@ if [[ "${aws_region:-null}" == "null" ]]; then
    fail "Region not specified in $build_file, exiting"
 fi
 
-# 
-# Search for source AMIs for all supported platforms
-aws_ubuntu_ebs_ami=$(aws-find-ami --build-file $build_file \
-                     --owners self \
-                     --region $aws_region \
-                     --virtualization-type hvm \
-                     --root-device-type ebs \
-                     --architecture x86_64 \
-                     --block-device-mapping.volume-type gp2 \
-                     --tag:platform ubuntu \
-                     $aws_find_ami_args)
+for builders in $(jq --raw-output '.builders[] | "\(.type)@\([.tags | .platform][])"' < $build_file); do
+   type=${builders%@*}
+   platform=${builders#*@}
 
-if [[ $? -ne 0 ]]; then
-   fail "aws-find-ami failed"
-fi
-
-aws_amazon_linux_ebs_ami=$(aws-find-ami --build-file $build_file \
-                           --owners self \
-                           --region $aws_region \
-                           --virtualization-type hvm \
-                           --root-device-type ebs \
-                           --architecture x86_64 \
-                           --block-device-mapping.volume-type gp2 \
-                           --tag:platform amazon-linux \
-                           $aws_find_ami_args)
-
-if [[ $? -ne 0 ]]; then
-   fail "aws-find-ami failed"
-fi
-
-aws_ubuntu_instance_ami=$(aws-find-ami --build-file $build_file \
-                          --owners self \
-                          --region $aws_region \
-                          --virtualization-type hvm \
-                          --root-device-type instance-store \
-                          --architecture x86_64 \
-                          --tag:platform ubuntu \
-                          $aws_find_ami_args)
-
-if [[ $? -ne 0 ]]; then
-   fail "aws-find-ami failed"
-fi
-
-aws_amazon_linux_instance_ami=$(aws-find-ami --build-file $build_file \
-                                --owners self \
-                                --region $aws_region \
-                                --virtualization-type hvm \
-                                --root-device-type instance-store \
-                                --architecture x86_64 \
-                                --tag:platform amazon-linux \
-                                $aws_find_ami_args)
-
-if [[ $? -ne 0 ]]; then
-   fail "aws-find-ami failed"
-fi
-
-cat << EOF > $output_file
-{
-  "variables": {
-    "aws_amazon_linux_ebs_ami": "${aws_amazon_linux_ebs_ami:-null}",
-    "aws_amazon_linux_instance_ami": "${aws_amazon_linux_instance_ami:-null}",
-    "aws_ubuntu_ebs_ami": "${aws_ubuntu_ebs_ami:-null}",
-    "aws_ubuntu_instance_ami": "${aws_ubuntu_instance_ami:-null}"
-  }
-}
-EOF
+   case $type in
+      amazon-ebs)
+         aws-find-ami --build-file $build_file \
+                      --output-file $output_file \
+                      --owners self \
+                      --region $aws_region \
+                      --virtualization-type hvm \
+                      --root-device-type ebs \
+                      --block-device-mapping.volume-type gp2 \
+                      --architecture x86_64 \
+                      --tag:platform $platform \
+                      $aws_find_ami_args || fail "aws-find-ami for $platform ebs had non-zero exit status"
+         ;;
+      amazon-instance)
+         aws-find-ami --build-file $build_file \
+                      --output-file $output_file \
+                      --owners self \
+                      --region $aws_region \
+                      --virtualization-type hvm \
+                      --root-device-type instance-store \
+                      --architecture x86_64 \
+                      --tag:platform $platform \
+                      $aws_find_ami_args || fail "aws-find-ami for $platform instance-store had non-zero exit status"
+         ;;
+      *)
+         fail "unknown build type $type"
+         ;;
+   esac
+done

--- a/packer/builders/amazon-ebs-amazon-linux.json
+++ b/packer/builders/amazon-ebs-amazon-linux.json
@@ -2,7 +2,7 @@
   "builders": [
   {
     "type": "amazon-ebs",
-    "name": "amazon-ebs-{{user `aws_region`}}-amazon-linux",
+    "name": "amazon-ebs-amazon-linux",
     "access_key": "{{user `aws_access_key`}}",
     "secret_key": "{{user `aws_secret_key`}}",
     "iam_instance_profile": "{{user `iam_instance_profile`}}",

--- a/packer/builders/amazon-ebs-ubuntu.json
+++ b/packer/builders/amazon-ebs-ubuntu.json
@@ -2,7 +2,7 @@
   "builders": [
   {
     "type": "amazon-ebs",
-    "name": "amazon-ebs-{{user `aws_region`}}-ubuntu",
+    "name": "amazon-ebs-ubuntu",
     "access_key": "{{user `aws_access_key`}}",
     "secret_key": "{{user `aws_secret_key`}}",
     "iam_instance_profile": "{{user `iam_instance_profile`}}",

--- a/packer/builders/amazon-instance-amazon-linux.json
+++ b/packer/builders/amazon-instance-amazon-linux.json
@@ -2,7 +2,7 @@
   "builders": [
   {
     "type": "amazon-instance",
-    "name": "amazon-instance-{{user `aws_region`}}-amazon-linux",
+    "name": "amazon-instance-amazon-linux",
     "access_key": "{{user `aws_access_key`}}",
     "secret_key": "{{user `aws_secret_key`}}",
     "s3_bucket": "{{user `aws_instance_s3_bucket`}}",
@@ -11,10 +11,10 @@
     "x509_key_path": "{{user `aws_x509_key_path`}}",
     "iam_instance_profile": "{{user `iam_instance_profile`}}",
     "region": "{{user `aws_region`}}",
-    "source_ami": "{{user `aws_amazon_linux_instance_ami`}}",
+    "source_ami": "{{user `aws_amazon_linux_instance_store_ami`}}",
     "instance_type": "m3.medium",
     "ssh_username": "ec2-user",
-    "ami_name": "{{user `project_name`}} {{user `project_version`}} instance amazon-linux",
+    "ami_name": "{{user `project_name`}} {{user `project_version`}} instance-store amazon-linux",
     "ami_description": "{{user `project_description`}}",
     "ami_regions" : ["eu-west-1", "us-east-1"],
     "bundle_vol_command": "sudo -i -n ec2-bundle-vol -k {{.KeyPath}} -u {{.AccountId}} -c {{.CertPath}} -r {{.Architecture}} -e {{.PrivatePath}}/* -d {{.Destination}} -p {{.Prefix}} --batch --no-filter",
@@ -23,7 +23,7 @@
        "project": "{{user `project_name`}}",
        "version": "{{user `project_version`}}",
        "platform": "amazon-linux",
-       "parent_source_ami": "{{user `aws_amazon_linux_instance_ami`}}"
+       "parent_source_ami": "{{user `aws_amazon_linux_instance_store_ami`}}"
     }
   }
   ]

--- a/packer/builders/amazon-instance-ubuntu.json
+++ b/packer/builders/amazon-instance-ubuntu.json
@@ -2,7 +2,7 @@
   "builders": [
   {
     "type": "amazon-instance",
-    "name": "amazon-instance-{{user `aws_region`}}-ubuntu",
+    "name": "amazon-instance-ubuntu",
     "access_key": "{{user `aws_access_key`}}",
     "secret_key": "{{user `aws_secret_key`}}",
     "s3_bucket": "{{user `aws_instance_s3_bucket`}}",
@@ -11,10 +11,10 @@
     "x509_key_path": "{{user `aws_x509_key_path`}}",
     "iam_instance_profile": "{{user `iam_instance_profile`}}",
     "region": "{{user `aws_region`}}",
-    "source_ami": "{{user `aws_ubuntu_instance_ami`}}",
+    "source_ami": "{{user `aws_ubuntu_instance_store_ami`}}",
     "instance_type": "m3.medium",
     "ssh_username": "ubuntu",
-    "ami_name": "{{user `project_name`}} {{user `project_version`}} instance ubuntu",
+    "ami_name": "{{user `project_name`}} {{user `project_version`}} instance-store ubuntu",
     "ami_description": "{{user `project_description`}}",
     "ami_regions" : ["eu-west-1", "us-east-1"],
     "bundle_upload_command": "sudo -i -n ec2-upload-bundle -b {{.BucketName}} -m {{.ManifestPath}} -a {{.AccessKey}} -s {{.SecretKey}} -d {{.BundleDirectory}} --batch --location {{.Region}} --retry",
@@ -22,7 +22,7 @@
        "project": "{{user `project_name`}}",
        "version": "{{user `project_version`}}",
        "platform": "ubuntu",
-       "parent_source_ami": "{{user `aws_ubuntu_instance_ami`}}"
+       "parent_source_ami": "{{user `aws_ubuntu_instance_store_ami`}}"
     }
   }
   ]


### PR DESCRIPTION
nubis-builder will now parse the build file and know what platforms it's building for, and only pull in the source ami IDs for those systems. this is a precursor to fix https://github.com/Nubisproject/nubis-builder/issues/8