### PR TITLE
Module improvements

### DIFF
--- a/bin/nubis-builder
+++ b/bin/nubis-builder
@@ -246,9 +246,13 @@ load_source_ami_ids(){
 # Kick off librarian-puppet and/or load puppet provisioners
 load_puppet(){
    if [[ -f ${project_path}/nubis/Puppetfile ]]; then
-      verbose_print "Running nubis-librarian-puppet --librarian-puppetfile $project_path/nubis/Puppetfile --librarian-puppet-path ${project_path}/nubis/nubis-puppet --json-file $nubis_build_file"
-      nubis-librarian-puppet --librarian-puppetfile $project_path/nubis/Puppetfile --librarian-puppet-path ${project_path}/nubis/nubis-puppet --json-file $nubis_build_file
+      nubis_librarian_puppet_args="--librarian-puppetfile $project_path/nubis/Puppetfile --librarian-puppet-path ${project_path}/nubis/librarian-puppet --json-file $nubis_build_file"
+      if [[ ${verbose:-0} -eq 1 ]]; then
+         nubis_librarian_puppet_args+=" --verbose"
+      fi
 
+      verbose_print "Running nubis-librarian-puppet ${nubis_librarian_puppet_args}"
+      nubis-librarian-puppet ${nubis_librarian_puppet_args}
       if [[ $? -ne 0 ]]; then
          message_print CRITICAL "nubis-librarian-puppet failed"
       fi

--- a/bin/nubis-builder
+++ b/bin/nubis-builder
@@ -121,7 +121,7 @@ sanitize_json(){
    sanitized_json_file=$(mktemp /tmp/${project_name:-nubis-UNKNOWN}.${output_name%%.*}.json.XXXXXXXX)
    json_data=$(cat $1)
 
-   for variable in .variables.aws_access_key .variables.aws_secret_key .variables.aws_account_id .variables.aws_x509_cert_path .variables.aws_x509_key_path; do
+   for variable in .variables.aws_access_key .variables.aws_secret_key .variables.aws_account_id .variables.aws_x509_cert_path .variables.aws_x509_key_path .variables.consul_address .variables.consul_token; do
       variable_data=$(echo "$json_data" | jq "$variable")
       if [[ "${variable_data:-null}" != "null" ]]; then
          json_data=$(echo "$json_data" | jq "$variable = \"<REDACTED>\"")
@@ -145,6 +145,12 @@ generate_packer_template(){
    provisioners=$(jq '.provisioners[]?' < $nubis_build_file)
    if [[ ! "$provisioners" ]]; then
       message_print CRITICAL "Project must have at least one provisioner"
+   fi
+
+   # Add the consul post-processor, if consul keys were defined somewhere in json
+   consul_address=$(jq --raw-output '"\(.variables.consul_address)"' < $nubis_build_file)
+   if [[ ${consul_address:-null} != null ]]; then
+      load_json $builder_prefix/packer/post-processors/consul.json
    fi
 
    # We add a meta parameter 'order' to the provisioners to ensure write our order, as packer

--- a/bin/nubis-librarian-puppet
+++ b/bin/nubis-librarian-puppet
@@ -6,10 +6,9 @@ usage(){
       echo
    fi
 
-   echo "Usage: $0 --librarian-puppetfile ~/path-to-project/nubis/Puppetfile --librarian-puppet-path ~/path-to-project/nubis/nubis-puppet --json-file project.json"
+   echo "Usage: $0 --librarian-puppetfile ~/path-to-project/nubis/Puppetfile --librarian-puppet-path ~/path-to-project/nubis/librarian-puppet --json-file project.json [--verbose]"
    echo
-   echo "This script will invoke librarian-puppet inside $librarian-puppet-path, hopefully populating all"
-   echo "the required files for a nubis based project."
+   echo "This script will invoke librarian-puppet inside $librarian-puppet-path"
    echo
    echo "Script is designed to be invoked by nubis-builder"
    echo
@@ -28,6 +27,7 @@ if [[ $# -lt 0 ]]; then
    usage
 fi
 
+librarian_puppet_args=""
 while [[ ! -z "$1" ]]; do
    case "$1" in
       --librarian-puppetfile)
@@ -39,10 +39,6 @@ while [[ ! -z "$1" ]]; do
          shift
          ;;
       --librarian-puppet-path)
-         librarian_puppet_parent=$(dirname $2)
-         if [[ ! -d $librarian_puppet_parent ]]; then
-            fail "Librarian path $2 doesn't have to exist, but it's parent directory has to"
-         fi
          librarian_puppet_path=$2
          shift
          ;;
@@ -53,6 +49,9 @@ while [[ ! -z "$1" ]]; do
             fail "JSON file $2 doesn't exist or is not a file"
          fi
          shift
+         ;;
+      --verbose)
+         librarian_puppet_args="--verbose"
          ;;
       *)
          usage "Invalid option $1"
@@ -81,18 +80,30 @@ fi
 librarian_puppetfile_directory=$(dirname $librarian_puppetfile)
 
 echo "$project_name: Cleaning out librarian-puppet in $librarian_puppetfile_directory"
-cd $librarian_puppetfile_directory && librarian-puppet clean
+cd $librarian_puppetfile_directory && librarian-puppet clean $librarian_puppet_args
 rm -f $librarian_puppetfile_directory/Puppetfile.lock
-rm -f $librarian_puppet_path/*.json
+rm -rf $librarian_puppet_path/etc/puppet
 
-echo "$project_name: Populating $librarian_puppet_path with librarian-puppet"
-cd $librarian_puppetfile_directory && librarian-puppet install --path $librarian_puppet_path
+# We're prefixing everything with /etc/puppet/modules because tar --transform (GNU) isn't portable
+# to BSD tar (such as on OSX).
+echo "$project_name: Creating $librarian_puppet_path/etc/puppet/modules"
+mkdir -p $librarian_puppet_path/etc/puppet/modules >/dev/null 2>&1
+
+# Run librarian-puppet and fetch modules
+echo "$project_name: Running librarian-puppet install --path $librarian_puppet_path/etc/puppet/modules"
+cd $librarian_puppetfile_directory && librarian-puppet install --path $librarian_puppet_path/etc/puppet/modules $librarian_puppet_args
 if [[ $? -ne 0 ]]; then
    fail "librarian-puppet failed"
 fi
 
-echo "$project_name: Running tar -C $librarian_puppet_parent --exclude='nubis-puppet/.*' --exclude=.git -zpcf $librarian_puppetfile_directory/nubis-puppet.tar.gz $(basename $librarian_puppet_path)"
-tar -C $librarian_puppet_parent --exclude='nubis-puppet/.*' --exclude=.git -zpcf $librarian_puppetfile_directory/nubis-puppet.tar.gz $(basename $librarian_puppet_path)
+# Copy over anything that belongs in /etc/puppet from $librarian_puppet_path/etc/puppet/modules/puppet
+for i in $(find $librarian_puppet_path/etc/puppet/modules/puppet -type f -and -not -name '.*' -maxdepth 1); do
+   cp -f $i $librarian_puppet_path/etc/puppet/
+done
+
+# Package it up
+echo "$project_name: Running tar -C $librarian_puppet_path --exclude='.*' -zpcf $librarian_puppetfile_directory/librarian-puppet.tar.gz ."
+tar -C $librarian_puppet_path --exclude='.*' -zpcf $librarian_puppetfile_directory/librarian-puppet.tar.gz .
 if [[ $? -ne 0 ]]; then
    fail "archive operation failed"
 fi

--- a/packer/post-processors/consul.json
+++ b/packer/post-processors/consul.json
@@ -1,0 +1,13 @@
+{
+"post-processors": [
+  {
+    "type": "consul",
+    "consul_address": "{{user `consul_address`}}",
+    "consul_token": "{{user `consul_token`}}",
+    "aws_access_key": "{{user `aws_access_key`}}",
+    "aws_secret_key": "{{user `aws_secret_key`}}",
+    "project_name": "{{user `project_name`}}",
+    "project_version": "{{user `project_version`}}"
+  }
+]
+}

--- a/packer/provisioners/librarian-puppet-masterless.json
+++ b/packer/provisioners/librarian-puppet-masterless.json
@@ -2,16 +2,16 @@
   "provisioners": [
   {
     "type": "file",
-    "source": "nubis/nubis-puppet.tar.gz",
-    "destination": "/tmp/nubis-puppet.tar.gz",
+    "source": "nubis/librarian-puppet.tar.gz",
+    "destination": "/tmp/librarian-puppet.tar.gz",
     "order": "0"
   },
   {
     "type": "puppet-masterless",
     "manifest_dir": "nubis/puppet",
     "manifest_file": "nubis/puppet/init.pp",
-    "module_paths": ["nubis/nubis-puppet"],
-    "hiera_config_path": "nubis/nubis-puppet/puppet/hiera.yaml",
+    "module_paths": ["nubis/librarian-puppet"],
+    "hiera_config_path": "nubis/librarian-puppet/etc/puppet/hiera.yaml",
     "facter": {
       "project_name": "{{user `project_name`}}",
       "project_version": "{{user `project_version`}}"

--- a/packer/provisioners/librarian-puppet-masterless.json
+++ b/packer/provisioners/librarian-puppet-masterless.json
@@ -10,7 +10,7 @@
     "type": "puppet-masterless",
     "manifest_dir": "nubis/puppet",
     "manifest_file": "nubis/puppet/init.pp",
-    "module_paths": ["nubis/librarian-puppet"],
+    "module_paths": ["nubis/librarian-puppet/etc/puppet/modules"],
     "hiera_config_path": "nubis/librarian-puppet/etc/puppet/hiera.yaml",
     "facter": {
       "project_name": "{{user `project_name`}}",

--- a/packer/provisioners/puppet-masterless.json
+++ b/packer/provisioners/puppet-masterless.json
@@ -4,6 +4,7 @@
     "type": "puppet-masterless",
     "manifest_dir": "nubis/puppet",
     "manifest_file": "nubis/puppet/init.pp",
+    "execute_command": "{{.FacterVars}} {{if .Sudo}} sudo -E {{end}} puppet apply --verbose --modulepath='/etc/puppet/modules/' {{if ne .HieraConfigPath \"\"}}--hiera_config='{{.HieraConfigPath}}' {{end}} {{if ne .ManifestDir \"\"}}--manifestdir='{{.ManifestDir}}' {{end}} --detailed-exitcodes {{.ManifestFile}}",
     "facter": {
       "project_name": "{{user `project_name`}}",
       "project_version": "{{user `project_version`}}"

--- a/packer/provisioners/puppet-masterless.json
+++ b/packer/provisioners/puppet-masterless.json
@@ -4,7 +4,6 @@
     "type": "puppet-masterless",
     "manifest_dir": "nubis/puppet",
     "manifest_file": "nubis/puppet/init.pp",
-    "execute_command": "{{.FacterVars}} {{if .Sudo}} sudo -E {{end}} puppet apply --verbose --modulepath='/etc/nubis-puppet/' {{if ne .HieraConfigPath \"\"}}--hiera_config='{{.HieraConfigPath}}' {{end}} {{if ne .ManifestDir \"\"}}--manifestdir='{{.ManifestDir}}' {{end}} --detailed-exitcodes {{.ManifestFile}}",
     "facter": {
       "project_name": "{{user `project_name`}}",
       "project_version": "{{user `project_version`}}"

--- a/secrets/variables.json-dist
+++ b/secrets/variables.json-dist
@@ -7,7 +7,9 @@
     "aws_instance_s3_bucket": "",
     "aws_x509_cert_path": "/full/path/to/secrets/aws.crt.pem",
     "aws_x509_key_path": "/full/path/to/secrets/aws.key.pem",
-    "iam_instance_profile": ""
+    "iam_instance_profile": "",
+    "consul_address": "consul.server:8500",
+    "consul_token": ""
   }
 }
 


### PR DESCRIPTION
Added consul post-processor to nubis-builder
Addresses https://github.com/Nubisproject/nubis-base/issues/65 (see https://github.com/Nubisproject/nubis-base/pull/68)
Passing along --verbose to librarian-puppet if nubis-builder is invoked with --verbose. It produces a lot more output, but previously, there was no way to debug librarian-puppet failures without running commands by hand.