### PR TITLE
Excluding AMIs who has a .Name which contains '.rc-', jq supports regex ...

### DIFF
--- a/bin/aws-find-ami
+++ b/bin/aws-find-ami
@@ -116,7 +116,7 @@ aws_ami_description=$(aws --output json --region $aws_region ec2 describe-images
 source_ami_project_name=$(jq --raw-output '"\(.variables.source_ami_project_name)"' < $build_file)
 if [[ "$source_ami_project_name" == "base" ]]; then
    # Sort base on image name
-   aws_ami_id=$(echo "$aws_ami_description" | jq --raw-output '[.Images[] | {Name, ImageId}] | sort_by(.Name) | .[length-1] | .ImageId')
+   aws_ami_id=$(echo "$aws_ami_description" | jq --raw-output '[.Images[] | {Name: .Name | select(contains(".rc-") | not), ImageId: .ImageId}] | sort_by(.Name) | .[length-1] | .ImageId')
    if [[ "${aws_ami_id:-null}" == "null" ]]; then
       fail "unable to find any ami matching filters"
    fi


### PR DESCRIPTION
...but not until 1.5 and we already manually upgraded to jq 1.4. This should be earmarked for future improvement

Addresses https://github.com/Nubisproject/nubis-builder/issues/34