### PR TITLE
Following the advice from https://www.packer.io/intro/getting-started/provision.html

### DIFF
--- a/packer/provisioners/housekeeper.json
+++ b/packer/provisioners/housekeeper.json
@@ -2,6 +2,11 @@
   "provisioners": [
   {
     "type": "shell",
+    "inline": "sleep 30"
+    "order": "0"
+  },
+  {
+    "type": "shell",
     "script": "{{user `builder_prefix`}}/nubis/bin/housekeeper",
     "order": "99999"
   }

--- a/packer/provisioners/wait-for-it.json
+++ b/packer/provisioners/wait-for-it.json
@@ -1,9 +1,0 @@
-{
-  "provisioners": [
-  {
-    "type": "shell",
-    "inline": "sleep 30"
-    "order": "0"
-  }
-  ]
-}

--- a/packer/provisioners/wait-for-it.json
+++ b/packer/provisioners/wait-for-it.json
@@ -1,0 +1,9 @@
+{
+  "provisioners": [
+  {
+    "type": "shell",
+    "inline": "sleep 30"
+    "order": "0"
+  }
+  ]
+}


### PR DESCRIPTION
Note: The sleep 30 in the example above is very important. Because Packer is able to
detect and SSH into the instance as soon as SSH is available, Ubuntu actually doesn't
get proper amounts of time to initialize. The sleep makes sure that the OS properly
initializes.