### PR TITLE
Code clean up and fixing instance-store builds 

### DIFF
--- a/bin/nubis-builder
+++ b/bin/nubis-builder
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Globals
-version=1.0
+version=1.1
 packer_options=""
 
 # Print some help

--- a/bin/nubis-builder
+++ b/bin/nubis-builder
@@ -147,8 +147,8 @@ setup_aws_config(){
    fi
 }
 
-# Load builder json
-load_builder_json(){
+# Load builder
+load_builder(){
    aws_access_key_id=$(jq --raw-output '"\(.variables.aws_access_key)"' < $nubis_json_file)
    aws_secret_access_key=$(jq --raw-output '"\(.variables.aws_secret_key)"' < $nubis_json_file)
 
@@ -162,53 +162,6 @@ load_builder_json(){
    fi
 }
 
-# Load builder
-load_builder(){
-   bundle_upload_command=$(jq --raw-output '. | .builders[].bundle_upload_command' 2>/dev/null < $1)
-
-   if [[ "${bundle_upload_command:-null}" != "null" ]]; then
-      aws_access_key_id=$(jq --raw-output '"\(.variables.aws_access_key)"' < $nubis_json_file)
-      aws_secret_access_key=$(jq --raw-output '"\(.variables.aws_secret_key)"' < $nubis_json_file)
-
-      if [[ "${aws_access_key_id:-null}" != "null" ]] || [[ "${aws_secret_access_key:-null}" != "null" ]]; then
-         # Access and secret keys were specified in the secret file, so we'll pass those directly on to the
-         # ec2-bundle-upload command.
-         verbose_print "Access and secret keys are present, parameterizing bundle_upload_command"
-         bundle_upload_command_args=" -a {{.AccessKey}} -s {{.SecretKey}}"
-      else
-         # Access or secret keys were not present, so we'll have to generate a temporary set using sts
-         # assume-role, if iam_instance_role is set.
-         iam_instance_role=$(jq --raw-output '"\(.variables.iam_instance_role)"' < $nubis_json_file)
-         if [[ "${iam_instance_role:-null}" != "null" ]]; then
-            verbose_print "Access and secret keys are not present but an iam instance role is set. Generating access keys with aws-sts-assume-role"
-
-            aws_sts_json_file=$(mktemp /tmp/aws_sts.json.XXXXXXXX)
-            verbose_print "Running aws-sts-assume-role --role-name $iam_instance_role --output-file $aws_sts_json_file"
-            aws-sts-assume-role --role-name "$iam_instance_role" --output-file "$aws_sts_json_file"
-            if [[ $? -eq 0 ]]; then
-               load_json "$aws_sts_json_file"
-
-               verbose_print "Access and secret key generation was successful, parameterizing bundle_upload_command."
-               bundle_upload_command_args=" -a {{user \`aws_sts_access_key\`}} -s {{user \`aws_sts_secret_key\`}} -t {{user \`aws_sts_session_token\`}}"
-            fi
-         else
-            verbose_print "aws_access_key and/or aws_secret_key undefined, iam_instance_role not set. instance building may not work."
-         fi
-      fi
-
-      if [[ "$bundle_upload_command_args" ]]; then
-         verbose_print "Appending $bundle_upload_command_args to bundle_upload_command in builder $1"
-
-         builder_template_file=$(mktemp /tmp/builder_template.json.XXXXXXXX)
-         jq ". | .builders[].bundle_upload_command += \"${bundle_upload_command_args}\"" < $1 > $builder_template_file
-         load_builder_json $builder_template_file
-         rm -f $builder_template_file
-      fi
-   else
-      load_builder_json $1
-   fi
-}
-
 # Sanitize json file after an error, hopefully this will help prevent accidental credential disclosure
 # by leaving files in /tmp
 sanitize_json(){
@@ -219,7 +172,7 @@ sanitize_json(){
    sanitized_json_file=$(mktemp /tmp/${project_name:-nubis-UNKNOWN}.${output_name%%.*}.json.XXXXXXXX)
    json_data=$(cat $1)
 
-   for variable in .variables.aws_access_key .variables.aws_secret_key .variables.aws_account_id .variables.aws_x509_cert_path .variables.aws_x509_key_path .variables.consul_address .variables.consul_token .variables.aws_sts_access_key .variables.aws_sts_secret_key .variables.aws_sts_session_token; do
+   for variable in .variables.aws_access_key .variables.aws_secret_key .variables.aws_account_id .variables.aws_x509_cert_path .variables.aws_x509_key_path; do
       variable_data=$(echo "$json_data" | jq "$variable")
       if [[ "${variable_data:-null}" != "null" ]]; then
          json_data=$(echo "$json_data" | jq "$variable = \"<REDACTED>\"")
@@ -245,10 +198,10 @@ generate_packer_template(){
       message_print CRITICAL "Project must have at least one provisioner"
    fi
 
-   # Add the housekeeper provisioner to clean up logs and ssh keys before packaging up
-   # the AMI
-   if [[ -r ${builder_prefix}/packer/provisioners/housekeeper.json ]]; then
-      load_json ${builder_prefix}/packer/provisioners/housekeeper.json
+   # Add the misc provisioner to clean up logs, purge ssh keys, and run other misc post
+   # build tasks
+   if [[ -r ${builder_prefix}/packer/provisioners/misc.json ]]; then
+      load_json ${builder_prefix}/packer/provisioners/misc.json
    fi
 
    # We add a meta parameter 'order' to the provisioners to ensure write our order, as packer

--- a/nubis/bin/README.md
+++ b/nubis/bin/README.md
@@ -5,6 +5,9 @@ Shell scripts that support the build process are located in this directory, and 
 script provisioner in packer. See the [packer documentation](https://www.packer.io/docs/provisioners/shell.html) 
 for more information.
 
+The scripts in nubis-builder/bin are build tool helpers, and will run on the local system. All of the scripts
+in here will be ran on the build target during the build process.
+
 #### housekeeper ####
 This shell script is responsible for truncating log files that were generated during the AMI build process, and 
 clearing out any ssh keys that were configured by cloud-init.

--- a/nubis/bin/s3-upload-bundle
+++ b/nubis/bin/s3-upload-bundle
@@ -22,7 +22,7 @@ else
 
    cd $(dirname $1)
    for image in $image_parts $1; do
-      s3cmd put $image $2
+      s3cmd --acl-grant=x-amz-acl:aws-exec-read put $image $2
       if [[ $? -ne 0 ]]; then
          echo "s3cmd put $image $2 failed"
          exit 1

--- a/nubis/bin/s3-upload-bundle
+++ b/nubis/bin/s3-upload-bundle
@@ -78,7 +78,9 @@ if [[ $? -ne 0 ]]; then
 fi
 
 cd $(dirname ${manifest_path})
-for image in $image_parts ${manifest_path}; do
+for i in $image_parts ${manifest_path}; do
+   image=$(basename $i)
+
    aws --region $region s3 cp $image s3://${bucket}
    if [[ $? -ne 0 ]]; then
       echo "aws s3 cp $image s3://${bucket} failed"

--- a/nubis/bin/s3-upload-bundle
+++ b/nubis/bin/s3-upload-bundle
@@ -10,7 +10,7 @@
 export PATH=/sbin:/bin:/usr/sbin:/usr/bin:/opt/aws/bin:/usr/local/bin
 
 if [[ $# -lt 2 ]]; then
-   echo "Usage: $0 --manifest-path <image manifest XML> --bucket <s3 bucket>"
+   echo "Usage: $0 --region <region> --manifest-path <image manifest XML> --bucket <s3 bucket>"
    exit 1
 fi
 
@@ -31,6 +31,14 @@ while [[ ! -z "$1" ]]; do
       --bucket)
          if [[ "$2" ]]; then
             bucket="$2"
+         else
+            fail "Must pass parameter to $1"
+         fi
+         shift
+         ;;
+      --region)
+         if [[ "$2" ]]; then
+            region="$2"
          else
             fail "Must pass parameter to $1"
          fi
@@ -57,11 +65,10 @@ fi
 if [[ -f /etc/debian_version ]]; then
    dpkg --get-selections libjson-any-perl | grep -q libjson-any-perl || apt-get -y install libjson-any-perl
    dpkg --get-selections libxml-simple-perl | grep -q libxml-simple-perl || apt-get -y install libxml-simple-perl
-   hash s3cmd || apt-get -y install s3cmd
+   dpkg --get-selections awscli | grep -q awscli || apt-get -y install awscli
 else
    rpm --quiet -q perl-JSON-Any || yum -y install perl-JSON-Any
    rpm --quiet -q perl-XML-Simple || yum -y install perl-XML-Simple
-   hash s3cmd || pip install s3cmd
 fi
 
 image_parts=$(perl -MJSON::Any -MXML::Simple -le"print JSON::Any->new()->objToJson(XMLin(\"${manifest_path}\"))" | jq --raw-output '.image | .parts | .part[] | .filename')
@@ -72,9 +79,9 @@ fi
 
 cd $(dirname ${manifest_path})
 for image in $image_parts ${manifest_path}; do
-   s3cmd --acl-grant=x-amz-acl:aws-exec-read put $image ${bucket}
+   aws --region $region s3 cp --acl public-read $image ${bucket}
    if [[ $? -ne 0 ]]; then
-      echo "s3cmd put $image s3://${bucket} failed"
+      echo "aws s3 cp --acl public-read $image ${bucket} failed"
       exit 1
    fi
 done

--- a/nubis/bin/s3-upload-bundle
+++ b/nubis/bin/s3-upload-bundle
@@ -88,11 +88,12 @@ for image in $image_parts ${manifest_path}; do
    # Some regions only provide eventual consistency, since the --acl option on 'aws s3' doesn't
    # support the AMI canned ACL we have to do it later, which gives us the opportunity to run
    # put-object-acl on a object that may have not reached full consistency. 
-   timer=60
+   timer=120
    plural="s"
-   until false; do
+   until aws s3 ls s3://${bucket}/${image} >/dev/null 2>&1; do
       if [[ ${timer} -lt 1 ]]; then
-         break
+         echo "Upload to S3 failed"
+         exit 1
       else
          if [[ ${timer} -eq 1 ]]; then
             plural=""

--- a/nubis/bin/s3-upload-bundle
+++ b/nubis/bin/s3-upload-bundle
@@ -79,9 +79,9 @@ fi
 
 cd $(dirname ${manifest_path})
 for image in $image_parts ${manifest_path}; do
-   aws --region $region s3 cp --acl public-read $image ${bucket}
+   aws --region $region s3 cp --acl aws-exec-read $image ${bucket}
    if [[ $? -ne 0 ]]; then
-      echo "aws s3 cp --acl public-read $image ${bucket} failed"
+      echo "aws s3 cp --acl aws-exec-read $image ${bucket} failed"
       exit 1
    fi
 done

--- a/nubis/bin/s3-upload-bundle
+++ b/nubis/bin/s3-upload-bundle
@@ -55,7 +55,9 @@ if [[ ! "$bucket" ]]; then
 fi
 
 if [[ -f /etc/debian_version ]]; then
-   echo "Sorry, ubuntu is not supported."
+   dpkg --get-selections libjson-any-perl | grep -q libjson-any-perl || apt-get -y install libjson-any-perl
+   dpkg --get-selections libxml-simple-perl | grep -q libxml-simple-perl || apt-get -y install libxml-simple-perl
+   hash s3cmd || apt-get -y install s3cmd
 else
    rpm --quiet -q perl-JSON-Any || yum -y install perl-JSON-Any
    rpm --quiet -q perl-XML-Simple || yum -y install perl-XML-Simple

--- a/nubis/bin/s3-upload-bundle
+++ b/nubis/bin/s3-upload-bundle
@@ -79,9 +79,34 @@ fi
 
 cd $(dirname ${manifest_path})
 for image in $image_parts ${manifest_path}; do
-   aws --region $region s3 cp --acl aws-exec-read $image ${bucket}
+   aws --region $region s3 cp $image s3://${bucket}
    if [[ $? -ne 0 ]]; then
-      echo "aws s3 cp --acl aws-exec-read $image ${bucket} failed"
+      echo "aws s3 cp $image s3://${bucket} failed"
+      exit 1
+   fi
+
+   # Some regions only provide eventual consistency, since the --acl option on 'aws s3' doesn't
+   # support the AMI canned ACL we have to do it later, which gives us the opportunity to run
+   # put-object-acl on a object that may have not reached full consistency. 
+   timer=60
+   plural="s"
+   until false; do
+      if [[ ${timer} -lt 1 ]]; then
+         break
+      else
+         if [[ ${timer} -eq 1 ]]; then
+            plural=""
+         fi
+
+         echo "Sleeping for 1 second until ${bucket}/${image} can become consistent (giving up in ${timer} second${plural})"
+         ((timer -= 1))
+         sleep 1
+      fi
+   done
+
+   aws s3api put-object-acl --bucket ${bucket} --key $image --acl aws-exec-read
+   if [[ $? -ne 0 ]]; then
+      echo "aws s3api put-object-acl --bucket ${bucket} --key $image --acl aws-exec-read failed"
       exit 1
    fi
 done

--- a/nubis/bin/s3-upload-bundle
+++ b/nubis/bin/s3-upload-bundle
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+export PATH=/sbin:/bin:/usr/sbin:/usr/bin:/opt/aws/bin:/usr/local/bin
+
+if [[ $# -lt 2 ]]; then
+   echo "Usage: $0 <image manifest XML> <s3 bucket path>"
+   exit 1
+fi
+
+if [[ -f /etc/debian_version ]]; then
+   echo "Sorry, ubuntu is not supported."
+else
+   rpm --quiet -q perl-JSON-Any || yum -y install perl-JSON-Any
+   rpm --quiet -q perl-XML-Simple || yum -y install perl-XML-Simple
+   hash s3cmd || pip install s3cmd
+
+   image_parts=$(perl -MJSON::Any -MXML::Simple -le"print JSON::Any->new()->objToJson(XMLin(\"$1\"))" | jq --raw-output '.image | .parts | .part[] | .filename')
+   if [[ $? -ne 0 ]]; then
+      echo "Failed to convert $1 to JSON"
+      exit 1
+   fi
+
+   cd $(dirname $1)
+   for image in $image_parts $1; do
+      s3cmd put $image $2
+      if [[ $? -ne 0 ]]; then
+         echo "s3cmd put $image $2 failed"
+         exit 1
+      fi
+   done
+
+fi

--- a/nubis/bin/s3-upload-bundle
+++ b/nubis/bin/s3-upload-bundle
@@ -72,7 +72,7 @@ fi
 
 cd $(dirname ${manifest_path})
 for image in $image_parts ${manifest_path}; do
-   s3cmd --acl-grant=x-amz-acl:aws-exec-read put $image s3://${bucket}
+   s3cmd --acl-grant=x-amz-acl:aws-exec-read put $image ${bucket}
    if [[ $? -ne 0 ]]; then
       echo "s3cmd put $image s3://${bucket} failed"
       exit 1

--- a/nubis/bin/s3-upload-bundle
+++ b/nubis/bin/s3-upload-bundle
@@ -1,9 +1,56 @@
 #!/bin/bash
+#
+# This script replaces ec2-upload-bundle when creating instance-store backed AMIs,
+# since ec2-upload-bundle won't work using an IAM role. Pulling credentials from
+# http://169.254.169.254/ won't work, either.
+#
+# https://forums.aws.amazon.com/thread.jspa?threadID=150584
+# https://github.com/Nubisproject/nubis-builder/issues/28
 
 export PATH=/sbin:/bin:/usr/sbin:/usr/bin:/opt/aws/bin:/usr/local/bin
 
 if [[ $# -lt 2 ]]; then
-   echo "Usage: $0 <image manifest XML> <s3 bucket path>"
+   echo "Usage: $0 --manifest-path <image manifest XML> --bucket <s3 bucket>"
+   exit 1
+fi
+
+while [[ ! -z "$1" ]]; do
+   case "$1" in
+      --manifest-path)
+         if [[ "$2" ]]; then
+            if [[ -r "$2" ]]; then
+               manifest_path="$2"
+            else
+               fail "File $2 is unreadable"
+            fi
+         else
+            fail "Must pass parameter to $1"
+         fi
+         shift
+         ;;
+      --bucket)
+         if [[ "$2" ]]; then
+            bucket="$2"
+         else
+            fail "Must pass parameter to $1"
+         fi
+         shift
+         ;;
+      *)
+         echo "Invalid option $1"
+         exit 1
+         ;;
+    esac
+    shift
+done
+
+if [[ ! "$manifest_path" ]]; then
+   echo "--manifest-path is a required parameter"
+   exit 1
+fi
+
+if [[ ! "$bucket" ]]; then
+   echo "--bucket is a required parameter"
    exit 1
 fi
 
@@ -13,20 +60,19 @@ else
    rpm --quiet -q perl-JSON-Any || yum -y install perl-JSON-Any
    rpm --quiet -q perl-XML-Simple || yum -y install perl-XML-Simple
    hash s3cmd || pip install s3cmd
+fi
 
-   image_parts=$(perl -MJSON::Any -MXML::Simple -le"print JSON::Any->new()->objToJson(XMLin(\"$1\"))" | jq --raw-output '.image | .parts | .part[] | .filename')
+image_parts=$(perl -MJSON::Any -MXML::Simple -le"print JSON::Any->new()->objToJson(XMLin(\"${manifest_path}\"))" | jq --raw-output '.image | .parts | .part[] | .filename')
+if [[ $? -ne 0 ]]; then
+   echo "Failed to convert ${manifest_path} to JSON"
+   exit 1
+fi
+
+cd $(dirname ${manifest_path})
+for image in $image_parts ${manifest_path}; do
+   s3cmd --acl-grant=x-amz-acl:aws-exec-read put $image s3://${bucket}
    if [[ $? -ne 0 ]]; then
-      echo "Failed to convert $1 to JSON"
+      echo "s3cmd put $image s3://${bucket} failed"
       exit 1
    fi
-
-   cd $(dirname $1)
-   for image in $image_parts $1; do
-      s3cmd --acl-grant=x-amz-acl:aws-exec-read put $image $2
-      if [[ $? -ne 0 ]]; then
-         echo "s3cmd put $image $2 failed"
-         exit 1
-      fi
-   done
-
-fi
+done

--- a/packer/builders/amazon-instance-amazon-linux.json
+++ b/packer/builders/amazon-instance-amazon-linux.json
@@ -18,7 +18,7 @@
     "ami_description": "{{user `project_description`}}",
     "ami_regions" : ["us-east-1"],
     "bundle_vol_command": "sudo -i -n ec2-bundle-vol -k {{.KeyPath}} -u {{.AccountId}} -c {{.CertPath}} -r {{.Architecture}} -e {{.PrivatePath}}/* -d {{.Destination}} -p {{.Prefix}} --batch --no-filter",
-    "bundle_upload_command": "sudo -i -n s3-upload-bundle --region {{.Region}} --manifest-path {{.ManifestPath}} --bucket s3://{{.BucketName}}/",
+    "bundle_upload_command": "sudo -i -n s3-upload-bundle --region {{.Region}} --manifest-path {{.ManifestPath}} --bucket {{.BucketName}}",
     "ami_groups" : "all",
     "tags" : {
        "project": "{{user `project_name`}}",

--- a/packer/builders/amazon-instance-amazon-linux.json
+++ b/packer/builders/amazon-instance-amazon-linux.json
@@ -18,7 +18,7 @@
     "ami_description": "{{user `project_description`}}",
     "ami_regions" : ["us-east-1"],
     "bundle_vol_command": "sudo -i -n ec2-bundle-vol -k {{.KeyPath}} -u {{.AccountId}} -c {{.CertPath}} -r {{.Architecture}} -e {{.PrivatePath}}/* -d {{.Destination}} -p {{.Prefix}} --batch --no-filter",
-    "bundle_upload_command": "sudo -i -n s3-upload-bundle {{.Prefix}} s3://{{.BucketName}}/",
+    "bundle_upload_command": "sudo -i -n s3-upload-bundle --manifest-path {{.ManifestPath}} --bucket s3://{{.BucketName}}/",
     "ami_groups" : "all",
     "tags" : {
        "project": "{{user `project_name`}}",

--- a/packer/builders/amazon-instance-amazon-linux.json
+++ b/packer/builders/amazon-instance-amazon-linux.json
@@ -18,7 +18,7 @@
     "ami_description": "{{user `project_description`}}",
     "ami_regions" : ["us-east-1"],
     "bundle_vol_command": "sudo -i -n ec2-bundle-vol -k {{.KeyPath}} -u {{.AccountId}} -c {{.CertPath}} -r {{.Architecture}} -e {{.PrivatePath}}/* -d {{.Destination}} -p {{.Prefix}} --batch --no-filter",
-    "bundle_upload_command": "sudo -i -n s3-upload-bundle --manifest-path {{.ManifestPath}} --bucket s3://{{.BucketName}}/",
+    "bundle_upload_command": "sudo -i -n s3-upload-bundle --region {{.Region}} --manifest-path {{.ManifestPath}} --bucket s3://{{.BucketName}}/",
     "ami_groups" : "all",
     "tags" : {
        "project": "{{user `project_name`}}",

--- a/packer/builders/amazon-instance-amazon-linux.json
+++ b/packer/builders/amazon-instance-amazon-linux.json
@@ -18,7 +18,7 @@
     "ami_description": "{{user `project_description`}}",
     "ami_regions" : ["us-east-1"],
     "bundle_vol_command": "sudo -i -n ec2-bundle-vol -k {{.KeyPath}} -u {{.AccountId}} -c {{.CertPath}} -r {{.Architecture}} -e {{.PrivatePath}}/* -d {{.Destination}} -p {{.Prefix}} --batch --no-filter",
-    "bundle_upload_command": "sudo -i -n ec2-upload-bundle -b {{.BucketName}} -m {{.ManifestPath}} -d {{.BundleDirectory}} --batch --location {{.Region}} --retry",
+    "bundle_upload_command": "sudo -i -n s3-upload-bundle {{.Prefix}} s3://{{.BucketName}}/"
     "ami_groups" : "all",
     "tags" : {
        "project": "{{user `project_name`}}",

--- a/packer/builders/amazon-instance-amazon-linux.json
+++ b/packer/builders/amazon-instance-amazon-linux.json
@@ -18,7 +18,7 @@
     "ami_description": "{{user `project_description`}}",
     "ami_regions" : ["us-east-1"],
     "bundle_vol_command": "sudo -i -n ec2-bundle-vol -k {{.KeyPath}} -u {{.AccountId}} -c {{.CertPath}} -r {{.Architecture}} -e {{.PrivatePath}}/* -d {{.Destination}} -p {{.Prefix}} --batch --no-filter",
-    "bundle_upload_command": "sudo -i -n s3-upload-bundle {{.Prefix}} s3://{{.BucketName}}/"
+    "bundle_upload_command": "sudo -i -n s3-upload-bundle {{.Prefix}} s3://{{.BucketName}}/",
     "ami_groups" : "all",
     "tags" : {
        "project": "{{user `project_name`}}",

--- a/packer/builders/amazon-instance-ubuntu.json
+++ b/packer/builders/amazon-instance-ubuntu.json
@@ -17,7 +17,7 @@
     "ami_name": "{{user `project_name`}} {{user `project_version`}} instance-store ubuntu",
     "ami_description": "{{user `project_description`}}",
     "ami_regions" : ["us-east-1"],
-    "bundle_upload_command": "sudo -i -n s3-upload-bundle {{.Prefix}} s3://{{.BucketName}}/"
+    "bundle_upload_command": "sudo -i -n s3-upload-bundle {{.Prefix}} s3://{{.BucketName}}/",
     "ami_groups" : "all",
     "tags" : {
        "project": "{{user `project_name`}}",

--- a/packer/builders/amazon-instance-ubuntu.json
+++ b/packer/builders/amazon-instance-ubuntu.json
@@ -17,7 +17,7 @@
     "ami_name": "{{user `project_name`}} {{user `project_version`}} instance-store ubuntu",
     "ami_description": "{{user `project_description`}}",
     "ami_regions" : ["us-east-1"],
-    "bundle_upload_command": "sudo -i -n s3-upload-bundle {{.Prefix}} s3://{{.BucketName}}/",
+    "bundle_upload_command": "sudo -i -n s3-upload-bundle --manifest-path {{.ManifestPath}} --bucket s3://{{.BucketName}}/",
     "ami_groups" : "all",
     "tags" : {
        "project": "{{user `project_name`}}",

--- a/packer/builders/amazon-instance-ubuntu.json
+++ b/packer/builders/amazon-instance-ubuntu.json
@@ -17,7 +17,7 @@
     "ami_name": "{{user `project_name`}} {{user `project_version`}} instance-store ubuntu",
     "ami_description": "{{user `project_description`}}",
     "ami_regions" : ["us-east-1"],
-    "bundle_upload_command": "sudo -i -n s3-upload-bundle --manifest-path {{.ManifestPath}} --bucket s3://{{.BucketName}}/",
+    "bundle_upload_command": "sudo -i -n s3-upload-bundle --region {{.Region}} --manifest-path {{.ManifestPath}} --bucket s3://{{.BucketName}}/",
     "ami_groups" : "all",
     "tags" : {
        "project": "{{user `project_name`}}",

--- a/packer/builders/amazon-instance-ubuntu.json
+++ b/packer/builders/amazon-instance-ubuntu.json
@@ -17,7 +17,7 @@
     "ami_name": "{{user `project_name`}} {{user `project_version`}} instance-store ubuntu",
     "ami_description": "{{user `project_description`}}",
     "ami_regions" : ["us-east-1"],
-    "bundle_upload_command": "sudo -i -n ec2-upload-bundle -b {{.BucketName}} -m {{.ManifestPath}} -d {{.BundleDirectory}} --batch --location {{.Region}} --retry",
+    "bundle_upload_command": "sudo -i -n s3-upload-bundle {{.Prefix}} s3://{{.BucketName}}/"
     "ami_groups" : "all",
     "tags" : {
        "project": "{{user `project_name`}}",

--- a/packer/builders/amazon-instance-ubuntu.json
+++ b/packer/builders/amazon-instance-ubuntu.json
@@ -17,7 +17,7 @@
     "ami_name": "{{user `project_name`}} {{user `project_version`}} instance-store ubuntu",
     "ami_description": "{{user `project_description`}}",
     "ami_regions" : ["us-east-1"],
-    "bundle_upload_command": "sudo -i -n s3-upload-bundle --region {{.Region}} --manifest-path {{.ManifestPath}} --bucket s3://{{.BucketName}}/",
+    "bundle_upload_command": "sudo -i -n s3-upload-bundle --region {{.Region}} --manifest-path {{.ManifestPath}} --bucket {{.BucketName}}",
     "ami_groups" : "all",
     "tags" : {
        "project": "{{user `project_name`}}",

--- a/packer/provisioners/housekeeper.json
+++ b/packer/provisioners/housekeeper.json
@@ -1,9 +1,0 @@
-{
-  "provisioners": [
-  {
-    "type": "shell",
-    "script": "{{user `builder_prefix`}}/nubis/bin/housekeeper",
-    "order": "99999"
-  }
-  ]
-}

--- a/packer/provisioners/misc.json
+++ b/packer/provisioners/misc.json
@@ -1,0 +1,20 @@
+{
+  "provisioners": [
+  {
+    "type": "file",
+    "source": "{{user `builder_prefix`}}/nubis/bin/s3-upload-bundle",
+    "destination": "/tmp/s3-upload-bundle",
+    "order": "99997"
+  },
+  {
+    "type": "shell",
+    "inline": "sudo mv /tmp/s3-upload-bundle /usr/local/sbin/s3-upload-bundle",
+    "order": "99998"
+  },
+  {
+    "type": "shell",
+    "script": "{{user `builder_prefix`}}/nubis/bin/housekeeper",
+    "order": "99999"
+  }
+  ]
+}

--- a/packer/provisioners/misc.json
+++ b/packer/provisioners/misc.json
@@ -13,7 +13,7 @@
   },
   {
     "type": "shell",
-    "inline": "sudo mv /tmp/s3-upload-bundle /usr/local/sbin/s3-upload-bundle",
+    "inline": "sudo install -o root -g 0 -m 0755 /tmp/s3-upload-bundle /usr/local/sbin",
     "order": "99998"
   },
   {

--- a/secrets/README.md
+++ b/secrets/README.md
@@ -22,9 +22,6 @@ Example variables.json:
     "aws_x509_cert_path": "/full/path/to/secrets/aws.crt.pem",
     "aws_x509_key_path": "/full/path/to/secrets/aws.key.pem",
     "iam_instance_profile": "",
-    "iam_instance_role": "",
-    "consul_address": "",
-    "consul_token": ""
   }
 }
 ```
@@ -50,9 +47,3 @@ aws_x509_key_path are passed to *ec2-bundle-vol* during the build process.
 #### iam_instance_profile ####
 This is the instance profile that your EC2 builders will be launched under. You can use this to facilitate 
 access to private S3 buckets, for example.
-
-#### iam_instance_role ####
-Feature under development. Documentation TBD.
-
-#### consul_address, consul_token ####
-Feature under development. Documentation TBD.

--- a/secrets/variables.json-dist
+++ b/secrets/variables.json-dist
@@ -8,9 +8,6 @@
     "aws_x509_cert_path": "/full/path/to/secrets/aws.crt.pem",
     "aws_x509_key_path": "/full/path/to/secrets/aws.key.pem",
     "iam_instance_profile": "",
-    "iam_instance_role": "",
-    "consul_address": "consul.server:8500",
-    "consul_token": ""
   }
 }
 


### PR DESCRIPTION
I've replaced ec2-upload-bundle and written my own. Digging into the internals all it does is upload the part files and manifest to s3, and setting a special ACL for access by the AMI deployment internals. 

I've removed some of the consul code which references a packer module which is no longer under development, and removed some of the STS token generation stuff that was being used in conjunction with ec2-upload-bundle.