### PR TITLE
Default to gp2 (SSD) drives for instances, but don't assume that when

### DIFF
--- a/bin/generate-source-ami-ids
+++ b/bin/generate-source-ami-ids
@@ -89,7 +89,6 @@ for builders in $(jq --raw-output '.builders[] | "\(.type)@\([.tags | .platform]
                       --region $aws_region \
                       --virtualization-type hvm \
                       --root-device-type ebs \
-                      --block-device-mapping.volume-type gp2 \
                       --architecture x86_64 \
                       --tag:platform $platform \
                       $aws_find_ami_args || fail "aws-find-ami for $platform ebs had non-zero exit status"

--- a/packer/builders/amazon-ebs-amazon-linux.json
+++ b/packer/builders/amazon-ebs-amazon-linux.json
@@ -16,6 +16,7 @@
     "ami_groups" : "all",
     "launch_block_device_mappings": [{
       "device_name": "/dev/xvda",
+      "volume_type": "gp2",
       "delete_on_termination": true
     }],
     "tags" : {

--- a/packer/builders/amazon-ebs-ubuntu.json
+++ b/packer/builders/amazon-ebs-ubuntu.json
@@ -16,6 +16,7 @@
     "ami_groups" : "all",
     "launch_block_device_mappings": [{
       "device_name": "/dev/sda1",
+      "volume_type": "gp2",
       "delete_on_termination": true
     }],
     "tags" : {


### PR DESCRIPTION
searching for AMI ids