### PR TITLE
Taking out the last trailing comma in variables

### DIFF
--- a/secrets/variables.json-dist
+++ b/secrets/variables.json-dist
@@ -7,7 +7,7 @@
     "aws_instance_s3_bucket": "",
     "aws_x509_cert_path": "/full/path/to/secrets/aws.crt.pem",
     "aws_x509_key_path": "/full/path/to/secrets/aws.key.pem",
-    "iam_instance_profile": "",
+    "iam_instance_profile": ""
   }
 }
 


### PR DESCRIPTION
variables.json-dist had a trailing comma in the last
pair which corrupts the json.