### PR TITLE
Fixes packer build issue after 0.8.1 upgrade

### DIFF
--- a/packer/builders/amazon-ebs-amazon-linux.json
+++ b/packer/builders/amazon-ebs-amazon-linux.json
@@ -10,6 +10,7 @@
     "source_ami": "{{user `aws_amazon_linux_ebs_ami`}}",
     "instance_type": "m3.medium",
     "ssh_username": "ec2-user",
+    "ssh_pty": "true",
     "ami_name": "{{user `project_name`}} {{user `project_version`}} ebs amazon-linux",
     "ami_description": "{{user `project_description`}}",
     "ami_regions" : ["us-east-1"],

--- a/packer/builders/amazon-ebs-ubuntu.json
+++ b/packer/builders/amazon-ebs-ubuntu.json
@@ -10,6 +10,7 @@
     "source_ami": "{{user `aws_ubuntu_ebs_ami`}}",
     "instance_type": "m3.medium",
     "ssh_username": "ubuntu",
+    "ssh_pty": "true",
     "ami_name": "{{user `project_name`}} {{user `project_version`}} ebs ubuntu",
     "ami_description": "{{user `project_description`}}",
     "ami_regions" : ["us-east-1"],


### PR DESCRIPTION
Changes between packer version means that we now need to set ```ssh_pty``` to ```true``` otherwise packer builds will fail with the message

> amazon-ebs-amazon-linux: sudo: sorry, you must have a tty to run sudo