### PR TITLE
Disable security updates on boot, fixes issue #77

### DIFF
--- a/packer/builders/amazon-ebs-amazon-linux.json
+++ b/packer/builders/amazon-ebs-amazon-linux.json
@@ -26,7 +26,8 @@
        "version": "{{user `project_version`}}",
        "platform": "amazon-linux",
        "parent_source_ami": "{{user `aws_amazon_linux_ebs_ami`}}"
-    }
+    },
+    "user_data": "I2Nsb3VkLWNvbmZpZwpyZXBvX3VwZ3JhZGU6IG5vbmUK"
   }
   ]
 }

--- a/packer/builders/amazon-instance-amazon-linux.json
+++ b/packer/builders/amazon-instance-amazon-linux.json
@@ -27,7 +27,8 @@
        "version": "{{user `project_version`}}",
        "platform": "amazon-linux",
        "parent_source_ami": "{{user `aws_amazon_linux_instance_store_ami`}}"
-    }
+    },
+    "user_data": "I2Nsb3VkLWNvbmZpZwpyZXBvX3VwZ3JhZGU6IG5vbmUK"
   }
   ]
 }


### PR DESCRIPTION
Annoying, because user_data in Packer needs to be base64 encoded,
and without comments, it leaves an opaque blob in the builder definition.

    $> echo I2Nsb3VkLWNvbmZpZwpyZXBvX3VwZ3JhZGU6IG5vbmUK | base64 -d
    #cloud-config
    repo_upgrade: none