### PR TITLE
Add a new variable, nubis_account_id, to allow nubis-builder to search for public AMIs (nubis-base) to derive builds from.

### DIFF
--- a/bin/generate-source-ami-ids
+++ b/bin/generate-source-ami-ids
@@ -71,6 +71,12 @@ fi
 
 # Region
 aws_region=$(jq --raw-output '"\(.variables.aws_region)"' < $build_file)
+nubis_account=$(jq --raw-output '"\(.variables.nubis_account_id)"' < $build_file)
+
+if [ -z "$nubis_account" ]; then
+  # Official Nubis Marketplace Account ID
+  nubis_account=589768463761
+fi
 
 # Verify that the parameter exists
 if [[ "${aws_region:-null}" == "null" ]]; then
@@ -85,7 +91,7 @@ for builders in $(jq --raw-output '.builders[] | "\(.type)@\([.tags | .platform]
       amazon-ebs)
          aws-find-ami --build-file $build_file \
                       --output-file $output_file \
-                      --owners self \
+                      --owners $nubis_account \
                       --region $aws_region \
                       --virtualization-type hvm \
                       --root-device-type ebs \
@@ -96,7 +102,7 @@ for builders in $(jq --raw-output '.builders[] | "\(.type)@\([.tags | .platform]
       amazon-instance)
          aws-find-ami --build-file $build_file \
                       --output-file $output_file \
-                      --owners self \
+                      --owners $nubis_account \
                       --region $aws_region \
                       --virtualization-type hvm \
                       --root-device-type instance-store \

--- a/secrets/README.md
+++ b/secrets/README.md
@@ -19,7 +19,8 @@ Quick start example variables.json:
     "aws_secret_key": "",
     "aws_account_id": "647505682097",
     "aws_region": "us-west-2",
-    "iam_instance_profile": ""
+    "iam_instance_profile": "",
+    "nubis_account_id": ""
   }
 }
 ```
@@ -36,7 +37,8 @@ Full example variables.json:
     "aws_instance_s3_bucket": "",
     "aws_x509_cert_path": "/full/path/to/secrets/aws.crt.pem",
     "aws_x509_key_path": "/full/path/to/secrets/aws.key.pem",
-    "iam_instance_profile": ""
+    "iam_instance_profile": "",
+    "nubis_account_id": ""
   }
 }
 ```
@@ -62,3 +64,7 @@ aws_x509_key_path are passed to *ec2-bundle-vol* during the build process.
 #### iam_instance_profile
 This is the instance profile that your EC2 builders will be launched under. You can use this to facilitate 
 access to private S3 buckets, for example.
+
+#### nubis_account_id
+This is the account ID where public Nubis images (like nubis-base) are published and should be searched for. You
+can set this to a different account if you wish or the special value 'self' to look in your own account.

--- a/secrets/variables.json-dist
+++ b/secrets/variables.json-dist
@@ -7,7 +7,8 @@
     "aws_instance_s3_bucket": "",
     "aws_x509_cert_path": "/full/path/to/secrets/aws.crt.pem",
     "aws_x509_key_path": "/full/path/to/secrets/aws.key.pem",
-    "iam_instance_profile": ""
+    "iam_instance_profile": "",
+    "nubis_account_id": "589768463761"
   }
 }
 


### PR DESCRIPTION
Currently defaults to the Nubis Marketplace account.

Fixes #82