### PR TITLE
Allow looking up public nubis-base images in a public account

### DIFF
--- a/bin/aws-find-ami
+++ b/bin/aws-find-ami
@@ -136,15 +136,21 @@ if [[ "$source_ami_project_name" == "base" ]]; then
          aws_ami_platform="unknown"
          ;;
    esac
-else
-   # Get data based on nubis specific tags
-   aws_ami_id=$(echo "$aws_ami_description" | jq --raw-output '[.Images[] | {id: .ImageId, version: .Tags[] | select(.Key == "version") | .Value}] | sort_by(.version | split(".") | map(tonumber)) | .[length-1] | .id')
+else # We are looking for a base image
+   # XXX: Wish we could lookup tags, but if the base images are not from our own account, we can't see tags
+
+   # We make the assumption here that images are named "nubis-base <version> <ebs|instance-store> <platform>"
+   aws_ami_id=$(echo "$aws_ami_description" | jq --raw-output '[.Images[] | {id: .ImageId, version: .Name | split(" ")[1]  }] | sort_by(.version | split(".") | map(tonumber)) | .[length-1] | .id'  )
+
    if [[ "${aws_ami_id:-null}" == "null" ]]; then
       fail "unable to find any ami matching filters"
    fi
 
    aws_ami_name=$(echo "$aws_ami_description" | jq --raw-output ".Images[] | {Name, ImageId} | select(.ImageId==\"${aws_ami_id}\") | .Name")
-   aws_ami_platform=$(echo "$aws_ami_description" | jq --raw-output "[.Images[] | {ImageId, Tags}][] | select(.ImageId==\"${aws_ami_id}\") | [.Tags[] | select(.Key==\"platform\")][] | .Value")
+
+   # We make the assumption here that images are named "nubis-base <version> <ebs|instance-store> <platform>"
+   aws_ami_platform=$(echo "$aws_ami_name" | awk '{print $4}')
+
    if [[ ! "$aws_ami_platform" ]]; then
       fail "ami id ${aws_ami_id} missing platform tag, aborting"
    fi

--- a/bin/generate-source-ami-ids
+++ b/bin/generate-source-ami-ids
@@ -24,17 +24,20 @@ fail(){
 
 aws_find_ami_args=""
 
+source_project_name="nubis-base"
+source_project_version="*"
+
 while [[ ! -z "$1" ]]; do
    case "$1" in
       --source-project-name)
          if [[ "$2" ]]; then
-             aws_find_ami_args="$aws_find_ami_args --tag:project $2"
+             source_project_name="$2"
          fi
          shift
          ;;
       --source-project-version)
          if [[ "$2" ]]; then
-             aws_find_ami_args="$aws_find_ami_args --tag:version $2"
+             source_project_version="$2"
          fi
          shift
          ;;
@@ -96,8 +99,7 @@ for builders in $(jq --raw-output '.builders[] | "\(.type)@\([.tags | .platform]
                       --virtualization-type hvm \
                       --root-device-type ebs \
                       --architecture x86_64 \
-                      --tag:platform $platform \
-                      $aws_find_ami_args || fail "aws-find-ami for $platform ebs had non-zero exit status"
+                      --name "$source_project_name*$source_project_version*ebs*$platform" || fail "aws-find-ami for $platform ebs had non-zero exit status"
          ;;
       amazon-instance)
          aws-find-ami --build-file $build_file \
@@ -107,8 +109,7 @@ for builders in $(jq --raw-output '.builders[] | "\(.type)@\([.tags | .platform]
                       --virtualization-type hvm \
                       --root-device-type instance-store \
                       --architecture x86_64 \
-                      --tag:platform $platform \
-                      $aws_find_ami_args || fail "aws-find-ami for $platform instance-store had non-zero exit status"
+                      --name "$source_project_name*$source_project_version*instance-store*$platform" || fail "aws-find-ami for $platform instance-store had non-zero exit status"
          ;;
       *)
          fail "unknown build type $type"


### PR DESCRIPTION
Since Amazon doesn't make public images tag's visible to other accounts,
we need a different mechanism to find them.

Instead, we can only rely on the Image's name, that's a bummer, so we
need to make the following assumption:

nubis-base images will always be named like:

  "nubis-base <version> <storage-type> <platform>"

Works, even if a bit brittle, IMO. Ideally, the long-term solution
would be to publish AMIs into the nubis-market account in a way that's
queryable

Fixes #84