### PR TITLE
Add functionlaity to support directory load model

### DIFF
--- a/bin/nubis-builder
+++ b/bin/nubis-builder
@@ -301,6 +301,13 @@ load_source_ami_ids(){
 
 # Kick off librarian-puppet and/or load puppet provisioners
 load_puppet(){
+   # If an init.pp file exists we will use it, otherwise use the new directory behavior
+   # http://docs.puppetlabs.com/puppet/3.8/reference/dirs_manifest.html#directory-behavior-vs-single-file
+   if [[ -f ${project_path}/nubis/puppet/init.pp ]]; then
+       PUPPET_PROVISIONER='puppet-masterless-init.json'
+   else
+       PUPPET_PROVISIONER='puppet-masterless.json'
+   fi
    if [[ -f ${project_path}/nubis/Puppetfile ]]; then
       nubis_librarian_puppet_args="--librarian-puppetfile ${project_path}/nubis/Puppetfile --librarian-puppet-path ${project_path}/nubis/librarian-puppet --json-file $nubis_json_file"
       if [[ ${verbose:-0} -eq 1 ]]; then
@@ -319,7 +326,7 @@ load_puppet(){
    fi
    # Load puppet provisioner if the project has a local puppet directory
    if [[ -d ${project_path}/nubis/puppet ]]; then
-      load_json ${builder_prefix}/packer/provisioners/puppet-masterless.json
+      load_json ${builder_prefix}/packer/provisioners/${PUPPET_PROVISIONER}
    fi
 }
 

--- a/packer/provisioners/puppet-masterless-init.json
+++ b/packer/provisioners/puppet-masterless-init.json
@@ -1,0 +1,15 @@
+{
+  "provisioners": [
+  {
+    "type": "puppet-masterless",
+    "manifest_dir": "nubis/puppet",
+    "manifest_file": "nubis/puppet/init.pp",
+    "execute_command": "{{.FacterVars}} {{if .Sudo}} sudo -E {{end}} puppet apply --verbose --modulepath='/etc/puppet/modules/' {{if ne .HieraConfigPath \"\"}}--hiera_config='{{.HieraConfigPath}}' {{end}} {{if ne .ManifestDir \"\"}}--manifestdir='{{.ManifestDir}}' {{end}} --detailed-exitcodes {{.ManifestFile}}",
+    "facter": {
+      "project_name": "{{user `project_name`}}",
+      "project_version": "{{user `project_version`}}"
+    },
+    "order": "10"
+  }
+  ]
+}

--- a/packer/provisioners/puppet-masterless.json
+++ b/packer/provisioners/puppet-masterless.json
@@ -3,8 +3,8 @@
   {
     "type": "puppet-masterless",
     "manifest_dir": "nubis/puppet",
-    "manifest_file": "nubis/puppet/init.pp",
-    "execute_command": "{{.FacterVars}} {{if .Sudo}} sudo -E {{end}} puppet apply --verbose --modulepath='/etc/puppet/modules/' {{if ne .HieraConfigPath \"\"}}--hiera_config='{{.HieraConfigPath}}' {{end}} {{if ne .ManifestDir \"\"}}--manifestdir='{{.ManifestDir}}' {{end}} --detailed-exitcodes {{.ManifestFile}}",
+    "manifest_file": "nubis/puppet",
+    "execute_command": "{{.FacterVars}} {{if .Sudo}} sudo -E {{end}} puppet apply --verbose --modulepath='/etc/puppet/modules/' {{if ne .HieraConfigPath \"\"}}--hiera_config='{{.HieraConfigPath}}' {{end}} --detailed-exitcodes {{.ManifestDir}}",
     "facter": {
       "project_name": "{{user `project_name`}}",
       "project_version": "{{user `project_version`}}"


### PR DESCRIPTION
Puppetlabs has changed the functionality from using an init.pp file to a directory loading model. You can read about the difference [here](http://docs.puppetlabs.com/puppet/3.8/reference/dirs_manifest.html#directory-behavior-vs-single-file).

This commit adds detection for using the depricated (and soon to be removed) method if an init.pp file exists. Otherwise it will use the new directory loading model.