### PR TITLE
If ATLAS_TOKEN and ATLAS_ORGANIZATION are set in the current environment, enable the Atlas artifact registration post-processor

### DIFF
--- a/bin/nubis-builder
+++ b/bin/nubis-builder
@@ -148,6 +148,14 @@ setup_aws_config(){
    fi
 }
 
+# Setup Atlas, if available
+setup_atlas(){
+    if [ "$ATLAS_TOKEN" != "" ] && [ "$ATLAS_ORGANIZATION" != "" ]; then
+        verbose_print "Enabling Atlas"
+        load_json ${builder_prefix}/packer/post-processors/atlas.json
+    fi
+}
+
 # Load builder
 load_builder(){
    aws_access_key_id=$(jq --raw-output '"\(.variables.aws_access_key)"' < $nubis_json_file)
@@ -501,6 +509,9 @@ build(){
 
    # Setup AWS config, if access/secret keys are present in $nubis_json_file
    setup_aws_config
+
+   # Setup Atlas, if configured
+   setup_atlas
 
    # Get the project name and version, these variables are used in some of the functions
    # called below

--- a/packer/post-processors/atlas.json
+++ b/packer/post-processors/atlas.json
@@ -1,0 +1,34 @@
+{
+  "variables": {
+    "atlas_organization": "{{env `ATLAS_ORGANIZATION`}}",
+    "atlas_build_id": "{{env `ATLAS_BUILD_ID`}}",
+    "atlas_build_number": "{{env `ATLAS_BUILD_NUMBER`}}",
+    "atlas_build_username": "{{env `ATLAS_BUILD_USERNAME`}}",
+    "atlas_build_configuration_version": "{{env `ATLAS_BUILD_CONFIGURATION_VERSION`}}",
+    "atlas_build_github_branch": "{{env `ATLAS_BUILD_GITHUB_BRANCH`}}",
+    "atlas_build_github_commit_sha": "{{env `ATLAS_BUILD_GITHUB_COMMIT_SHA`}}",
+    "atlas_build_github_tag": "{{env `ATLAS_BUILD_GITHUB_TAG`}}"
+  },
+  "post-processors": [
+    {
+      "type": "atlas",
+      "artifact": "{{user `atlas_organization`}}/{{user `project_name`}}",
+      "artifact_type": "amazon.image",
+      "metadata": {
+        "atlas_build_id": "{{user `atlas_build_id`}}",
+        "atlas_build_number": "{{user `atlas_build_number`}}",
+        "atlas_build_username": "{{user `atlas_build_username`}}",
+        "atlas_build_configuration_version": "{{user `atlas_build_configuration_version`}}",
+        "atlas_build_github_branch": "{{user `atlas_build_github_branch`}}",
+        "atlas_build_github_commit_sha": "{{user `atlas_build_github_commit_sha`}}",
+        "atlas_build_github_tag": "{{user `atlas_build_github_tag`}}",
+        "project_name": "{{user `project_name`}}",
+        "project_version": "{{user `project_version`}}",
+        "project_description": "{{user `project_description`}}",
+        "source_ami_project_name": "{{ user `source_ami_project_name` }}",
+        "build_name": "{{ build_name }}",
+        "build_type": "{{ build_type }}"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Note: ATLAS_ORGANIZATION is not a native Atlas environment variable.