### PR TITLE
Remove unneeded ATLAS_ORGANIZATION support, Atlas tells us this

### DIFF
--- a/bin/nubis-builder
+++ b/bin/nubis-builder
@@ -150,7 +150,7 @@ setup_aws_config(){
 
 # Setup Atlas, if available
 setup_atlas(){
-    if [ "$ATLAS_TOKEN" != "" ] && [ "$ATLAS_ORGANIZATION" != "" ]; then
+    if [ "$ATLAS_TOKEN" != "" ]; then
         verbose_print "Enabling Atlas"
         load_json ${builder_prefix}/packer/post-processors/atlas.json
     fi

--- a/packer/post-processors/atlas.json
+++ b/packer/post-processors/atlas.json
@@ -1,6 +1,5 @@
 {
   "variables": {
-    "atlas_organization": "{{env `ATLAS_ORGANIZATION`}}",
     "atlas_build_id": "{{env `ATLAS_BUILD_ID`}}",
     "atlas_build_number": "{{env `ATLAS_BUILD_NUMBER`}}",
     "atlas_build_username": "{{env `ATLAS_BUILD_USERNAME`}}",
@@ -12,7 +11,7 @@
   "post-processors": [
     {
       "type": "atlas",
-      "artifact": "{{user `atlas_organization`}}/{{user `project_name`}}",
+      "artifact": "{{user `atlas_build_username`}}/{{user `project_name`}}",
       "artifact_type": "amazon.image",
       "metadata": {
         "atlas_build_id": "{{user `atlas_build_id`}}",


### PR DESCRIPTION
via the ATLAS_BUILD_USERNAME environment variable

So there was no need to add a custom ATLAS_* environment variable.

Now, all that's needed is for ATLAS_TOKEN to be set, and we ship to Atlas