### PR TITLE
Prototype: Support for a 'docker-ubuntu' builder type, based on LTS

### DIFF
--- a/bin/generate-base-ami-ids
+++ b/bin/generate-base-ami-ids
@@ -72,6 +72,8 @@ for builders in $(jq --raw-output '.builders[] | "\(.type)@\([.tags | .platform]
    platform=${builders#*@}
 
    case $type in
+      docker)
+          ;;
       amazon-ebs)
          case $platform in
             ubuntu)

--- a/bin/generate-source-ami-ids
+++ b/bin/generate-source-ami-ids
@@ -91,6 +91,8 @@ for builders in $(jq --raw-output '.builders[] | "\(.type)@\([.tags | .platform]
    platform=${builders#*@}
 
    case $type in
+      docker)
+          ;;
       amazon-ebs)
          aws-find-ami --build-file $build_file \
                       --output-file $output_file \

--- a/packer/builders/docker-ubuntu.json
+++ b/packer/builders/docker-ubuntu.json
@@ -1,0 +1,24 @@
+{
+  "builders": [
+    {
+      "type": "docker",
+      "name": "docker-ubuntu",
+      "image": "ubuntu:14.04",
+      "commit": true
+    }
+  ],
+  "post-processors": [
+    [
+      {
+        "type": "docker-tag",
+        "repository": "{{user `project_name`}}",
+        "tag": "{{user `project_version`}}"
+      },
+      {
+        "type": "docker-tag",
+        "repository": "{{user `project_name`}}",
+        "tag": "latest"
+      }
+    ]
+  ]
+}


### PR DESCRIPTION
This is effectively similar to the amazon-ebs-ubuntu, but a docker-local
build.

Resulting image is just tagged at the moment, it doesn't go anywhere.