### PR TITLE
Add a --builders option to override which builders to use.

### DIFF
--- a/bin/nubis-builder
+++ b/bin/nubis-builder
@@ -12,7 +12,7 @@ usage() {
       echo
    fi
 
-   echo "Usage: $0 build [--builder-prefix <path to nubis-builder checkout>] [--project-path <path to project>] [--json-file <path to extra json files>] [--packer-option <option>] [--keep-json] [--verbose]"
+   echo "Usage: $0 build [--builder-prefix <path to nubis-builder checkout>] [--project-path <path to project>] [--json-file <path to extra json files>] [--packer-option <option>] [--keep-json] [--verbose] [--builders <builders>"
    echo
    echo "This script is the nubis build tool which will take a local checkout of a project and"
    echo "subject it to the build processes that have been developed for the nubis project."
@@ -453,6 +453,10 @@ build(){
          --verbose)
             verbose=1
             ;;
+         --builders)
+           builders_option=$2
+           shift
+           ;;
          *)
             usage "Invalid option $1"
        esac
@@ -487,7 +491,12 @@ build(){
 
    # Load builders
     declare -a PACKER_BUILDERS
-   for builder in $(jq --raw-output '"\(.variables.builders[])"' < $nubis_json_file); do
+   if [[ "$builders_option" ]]; then
+     BUILDERS="$builders_option"
+   else
+     BUILDERS=$(jq --raw-output '"\(.variables.builders[])"' < $nubis_json_file)
+   fi
+   for builder in $BUILDERS; do
       if [[ -f ${builder_prefix}/packer/builders/${builder}.json ]]; then
          verbose_print "Loading builder $builder from ${builder_prefix}/packer/builders"
          load_builder ${builder_prefix}/packer/builders/${builder}.json


### PR DESCRIPTION
For instance

$> nubis-builder build --builders 'amazon-ebs-ubuntu amazon-ebs-amazon-linux'

Fixes #134