### PR TITLE
Handle semantic versionning when we sort versions.

### DIFF
--- a/bin/aws-find-ami
+++ b/bin/aws-find-ami
@@ -140,7 +140,7 @@ else # We are looking for a base image
    # XXX: Wish we could lookup tags, but if the base images are not from our own account, we can't see tags
 
    # We make the assumption here that images are named "nubis-base <version> <ebs|instance-store> <platform>"
-   aws_ami_id=$(echo "$aws_ami_description" | jq --raw-output '[.Images[] | {id: .ImageId, version: .Name | split(" ")[1]  }] | sort_by(.version | split(".") | map(tonumber)) | .[length-1] | .id'  )
+   aws_ami_id=$(echo "$aws_ami_description" | jq --raw-output '[.Images[] | {id: .ImageId, version: .Name | split(" ")[1]  }] | sort_by(.version | sub("^v";"") | splits("-|\\.") | if test("^[0-9]+$") then tonumber else . end) | .[length-1] | .id'  )
 
    if [[ "${aws_ami_id:-null}" == "null" ]]; then
       fail "unable to find any ami matching filters"

--- a/bin/generate-source-ami-ids
+++ b/bin/generate-source-ami-ids
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -x
+
 usage(){
    if [[ $# -gt 0 ]]; then
       echo "$@"

--- a/bin/generate-source-ami-ids
+++ b/bin/generate-source-ami-ids
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -x
-
 usage(){
    if [[ $# -gt 0 ]]; then
       echo "$@"

--- a/bin/nubis-verify-version
+++ b/bin/nubis-verify-version
@@ -92,7 +92,8 @@ latest_ami_json=$(aws --output json --region $aws_region ec2 describe-images --o
 rm -f $aws_config
 
 if [[ "$latest_ami_json" ]]; then
-   project_ami_version=$(echo "$latest_ami_json" | jq -r '[.Images[] | .Tags[] | select(.Key=="version")] | sort_by(.Value | split(".") | map(tonumber)) | .[length-1] | .Value')
+   project_ami_version=$(echo "$latest_ami_json" | jq -r '[.Images[] | .Tags[] | select(.Key=="version")] | sort_by(.Value | sub("^v";"") | splits("-|\\.") | if test("^[0-9]+$") then tonum
+ber else . end ) | .[length-1] | .Value')
 
    if [[ "${project_ami_version:null}" != "null" ]]; then
       # Version collision is a bit of a misnomer since we're not actually checking if the local version already

--- a/bin/nubis-verify-version
+++ b/bin/nubis-verify-version
@@ -91,9 +91,9 @@ latest_ami_json=$(aws --output json --region $aws_region ec2 describe-images --o
 # Clean up temp config
 rm -f $aws_config
 
+set -x
 if [[ "$latest_ami_json" ]]; then
-   project_ami_version=$(echo "$latest_ami_json" | jq -r '[.Images[] | .Tags[] | select(.Key=="version")] | sort_by(.Value | sub("^v";"") | splits("-|\\.") | if test("^[0-9]+$") then tonum
-ber else . end ) | .[length-1] | .Value')
+   project_ami_version=$(echo "$latest_ami_json" | jq -r '[.Images[] | .Tags[] | select(.Key=="version")] | sort_by(.Value | sub("^v";"") | splits("-|\\.") | if test("^[0-9]+$") then tonumber else . end ) | .[length-1] | .Value')
 
    if [[ "${project_ami_version:null}" != "null" ]]; then
       # Version collision is a bit of a misnomer since we're not actually checking if the local version already

--- a/bin/nubis-verify-version
+++ b/bin/nubis-verify-version
@@ -91,7 +91,6 @@ latest_ami_json=$(aws --output json --region $aws_region ec2 describe-images --o
 # Clean up temp config
 rm -f $aws_config
 
-set -x
 if [[ "$latest_ami_json" ]]; then
    project_ami_version=$(echo "$latest_ami_json" | jq -r '[.Images[] | .Tags[] | select(.Key=="version")] | sort_by(.Value | sub("^v";"") | splits("-|\\.") | if test("^[0-9]+$") then tonumber else . end ) | .[length-1] | .Value')
 


### PR DESCRIPTION
Fairly complex jq madness, explained:
```code
sort_by(.version                                  # start with the version string  (v1.0.2-foo)
  | sub("^v";"")                                  # strip leading optionnal v      (1.0.2-foo)
  | splits("-|\\.")                               # split on - or .                (["1","0","2","foo"])
  | if test("^[0-9]+$") then tonumber else . end) # convert numbers to integers    ([1,0,2,"foo"])
                                                  # sort the by these version arrays
  | .[length-1]                                   # grab the last one.
```
The nice things is that it can sort proprely:
 1.102
 v1.0.2.3.4
 v1.0.2-alpha1

Fixes #140