### PR TITLE
Use nubis-base as the default AMIs to build from

### DIFF
--- a/bin/nubis-builder
+++ b/bin/nubis-builder
@@ -278,11 +278,6 @@ load_source_ami_ids(){
       verbose_print "Defaulting to using nubis-base as a base"
    fi
 
-   if [[ ${source_ami_project_version:-null} == null ]]; then
-      source_ami_project_version=$(jq --raw-output '"\(.variables.project_version)"' < $nubis_json_file)
-      verbose_print "Defaulting to using $source_ami_project_version as base version"
-   fi
-
    ami_json_file=$(mktemp /tmp/source_ami_ids.json.XXXXXXXX)
 
    if [[ "$source_ami_project_name" == "base" ]]; then
@@ -298,6 +293,11 @@ load_source_ami_ids(){
          message_print CRITICAL "generate-base-ami-ids failed"
       fi
    else
+      if [[ ${source_ami_project_version:-null} == null ]]; then
+        source_ami_project_version=$(jq --raw-output '"\(.variables.project_version)"' < $nubis_json_file)
+        verbose_print "Defaulting to using $source_ami_project_version as base version"
+      fi
+
       generate_source_ami_ids_args="--source-project-name $source_ami_project_name --build-file $nubis_json_file --output-file $ami_json_file"
       if [[ "$source_ami_project_version" != "null" ]]; then
          generate_source_ami_ids_args="$generate_source_ami_ids_args --source-project-version $source_ami_project_version"

--- a/bin/nubis-builder
+++ b/bin/nubis-builder
@@ -274,7 +274,13 @@ bump_version(){
 load_source_ami_ids(){
    # Get source project name, and version if set.
    if [[ ${source_ami_project_name:-null} == null ]]; then
-      message_print CRITICAL "source_ami_project_name is a required parameter in the project file"
+      source_ami_project_name="nubis-base"
+      message_print OK "Defaulting to using nubis-base as a base"
+   fi
+
+   if [[ ${source_ami_project_version:-null} == null ]]; then
+      source_ami_project_version=$(jq --raw-output '"\(.variables.project_version)"' < $nubis_json_file)
+      message_print OK "Defaulting to using $source_ami_project_version as base version"
    fi
 
    ami_json_file=$(mktemp /tmp/source_ami_ids.json.XXXXXXXX)

--- a/bin/nubis-builder
+++ b/bin/nubis-builder
@@ -275,12 +275,12 @@ load_source_ami_ids(){
    # Get source project name, and version if set.
    if [[ ${source_ami_project_name:-null} == null ]]; then
       source_ami_project_name="nubis-base"
-      message_print OK "Defaulting to using nubis-base as a base"
+      verbose_print "Defaulting to using nubis-base as a base"
    fi
 
    if [[ ${source_ami_project_version:-null} == null ]]; then
       source_ami_project_version=$(jq --raw-output '"\(.variables.project_version)"' < $nubis_json_file)
-      message_print OK "Defaulting to using $source_ami_project_version as base version"
+      verbose_print "Defaulting to using $source_ami_project_version as base version"
    fi
 
    ami_json_file=$(mktemp /tmp/source_ami_ids.json.XXXXXXXX)


### PR DESCRIPTION
While at it, default to project_version (i.e. 1.0.2-dev) for the base
image version, if unspecified

Fixes #146