### PR TITLE
Retrieve puppet package list locally, into nubis/builder/AMI-{{ build_name }}-package-versions.pp

### DIFF
--- a/packer/provisioners/misc.json
+++ b/packer/provisioners/misc.json
@@ -9,6 +9,13 @@
     "type": "shell",
     "inline": "test -x /usr/local/bin/nubis-housekeeper && /usr/local/bin/nubis-housekeeper || true",
     "order": "99999"
+  },
+  {
+    "type": "file",
+    "destination": "nubis/builder/AMI-{{ build_name }}-package-versions.pp",
+    "source": "/etc/puppet/package-versions.pp",
+    "direction": "download",
+    "order": "99999"
   }
   ]
 }

--- a/packer/provisioners/misc.json
+++ b/packer/provisioners/misc.json
@@ -8,7 +8,7 @@
   {
     "type": "shell",
     "inline": "test -x /usr/local/bin/nubis-housekeeper && /usr/local/bin/nubis-housekeeper || true",
-    "order": "99999"
+    "order": "99998"
   },
   {
     "type": "file",


### PR DESCRIPTION
Fixes #148