### PR TITLE
Add force_delete_snapshot to clean up AMI snapshots when we replace an AMI

### DIFF
--- a/packer/builders/amazon-ebs-amazon-linux.json
+++ b/packer/builders/amazon-ebs-amazon-linux.json
@@ -13,6 +13,7 @@
     "region": "{{user `aws_region`}}",
     "source_ami": "{{user `aws_amazon_linux_ebs_ami`}}",
     "force_deregister": "true",
+    "force_delete_snapshot" : "true",
     "instance_type": "c3.large",
     "ssh_username": "ec2-user",
     "ssh_pty": "true",

--- a/packer/builders/amazon-ebs-centos.json
+++ b/packer/builders/amazon-ebs-centos.json
@@ -13,6 +13,7 @@
     "region": "{{user `aws_region`}}",
     "source_ami": "{{user `aws_centos_ebs_ami`}}",
     "force_deregister": "true",
+    "force_delete_snapshot" : "true",
     "instance_type": "c3.large",
     "ssh_username": "centos",
     "ssh_pty": "true",

--- a/packer/builders/amazon-ebs-ubuntu.json
+++ b/packer/builders/amazon-ebs-ubuntu.json
@@ -13,6 +13,7 @@
     "region": "{{user `aws_region`}}",
     "source_ami": "{{user `aws_ubuntu_ebs_ami`}}",
     "force_deregister": "true",
+    "force_delete_snapshot" : "true",
     "instance_type": "c3.large",
     "ssh_username": "ubuntu",
     "ssh_pty": "true",


### PR DESCRIPTION
Fixes #191