### PR TITLE
Add --spot option to request building with Spot instances

### DIFF
--- a/bin/nubis-builder
+++ b/bin/nubis-builder
@@ -14,7 +14,7 @@ usage() {
       echo
    fi
 
-   echo "Usage: $0 build [--builder-prefix <path to nubis-builder checkout>] [--project-path <path to project>] [--json-file <path to extra json files>] [--packer-option <option>] [--keep-json] [--verbose] [--builders <builders>]"
+   echo "Usage: $0 build [--builder-prefix <path to nubis-builder checkout>] [--project-path <path to project>] [--json-file <path to extra json files>] [--packer-option <option>] [--keep-json] [--verbose] [--spot] [--builders <builders>]"
    echo
    echo "This script is the nubis build tool which will take a local checkout of a project and"
    echo "subject it to the build processes that have been developed for the nubis project."
@@ -247,6 +247,7 @@ generate_packer_template(){
    jq ". + { \"provisioners\": .provisioners | sort_by(.order | tonumber) } |
        del(.provisioners[] | .order) |
        del(.variables.builders) |
+       .variables.spot_price = \"${spot_price:-0}\" |
        .variables.builder_prefix = \"${builder_prefix}\" |
        .variables.project_path = \"${project_path}\"" < $nubis_json_file > $packer_template_file
 
@@ -500,6 +501,9 @@ build(){
             ;;
          --verbose)
             verbose=1
+            ;;
+         --spot)
+            spot_price="auto"
             ;;
          --builders)
            builders_option=$2

--- a/packer/builders/amazon-ebs-amazon-linux.json
+++ b/packer/builders/amazon-ebs-amazon-linux.json
@@ -20,6 +20,8 @@
     "ami_description": "{{user `project_description`}}",
     "ami_regions": "{{user `ami_regions`}}",
     "ami_groups" : "all",
+    "spot_price" : "{{user `spot_price`}}",
+    "spot_price_auto_product": "Linux/UNIX",
     "tags" : {
        "project": "{{user `project_name`}}",
        "version": "{{user `project_version`}}",

--- a/packer/builders/amazon-ebs-centos.json
+++ b/packer/builders/amazon-ebs-centos.json
@@ -20,6 +20,8 @@
     "ami_description": "{{user `project_description`}}",
     "ami_regions": "{{user `ami_regions`}}",
     "ami_groups" : "all",
+    "spot_price" : "{{user `spot_price`}}",
+    "spot_price_auto_product": "Linux/UNIX",
     "tags" : {
        "project": "{{user `project_name`}}",
        "version": "{{user `project_version`}}",

--- a/packer/builders/amazon-ebs-ubuntu.json
+++ b/packer/builders/amazon-ebs-ubuntu.json
@@ -20,6 +20,8 @@
     "ami_description": "{{user `project_description`}}",
     "ami_regions" : "{{user `ami_regions`}}",
     "ami_groups" : "all",
+    "spot_price" : "{{user `spot_price`}}",
+    "spot_price_auto_product": "Linux/UNIX",
     "tags" : {
        "project": "{{user `project_name`}}",
        "version": "{{user `project_version`}}",


### PR DESCRIPTION
Default is disabled

NOTE: spot_price=0 in Packer translates to requesting On-Demand instances

Fixes #196