### PR TITLE
Include the packer build UUID in the generated /etc/<project>-release file

### DIFF
--- a/packer/provisioners/project-release.json
+++ b/packer/provisioners/project-release.json
@@ -1,8 +1,11 @@
 {
+  "variables": {
+    "packer_run_uuid": "{{env `PACKER_RUN_UUID`}}"
+  },
   "provisioners": [
   {
     "type": "shell",
-    "inline": "echo {{user `project_name`}} {{user `project_version`}} | sudo tee -a /etc/{{user `project_name`}}-release",
+    "inline": "echo {{user `project_name`}} {{user `project_version`}} {{user `packer_run_uuid`}} | sudo tee -a /etc/{{user `project_name`}}-release",
     "order": "0"
   }
   ]


### PR DESCRIPTION
Will end up changing from:

```
nubis-base v1.4.0
```

to
```
nubis-base v1.4.0 917d5318-7376-b0fc-2ed3-6f1b2f4d01ad
```

And it's purely cosmetic, no automation uses this