### PR TITLE
Use bash to truncate

### DIFF
--- a/bin/nubis-builder
+++ b/bin/nubis-builder
@@ -672,7 +672,7 @@ run_packer_build () {
             message_print 'VERBOSE' "Cleaning up AMIs.json file"
             message_print 'VERBOSE' "File: '${BASH_SOURCE[0]}' Line: '${LINENO}'"
             mkdir -p "${PROJECT_PATH}/nubis/builder/artifacts"
-            truncate --size 0 "${PROJECT_PATH}/nubis/builder/artifacts/AMIs.json"
+            :> "${PROJECT_PATH}/nubis/builder/artifacts/AMIs.json"
 
             message_print 'OK' "Running packer build ${PACKER_TEMPLATE_FILE}"
             message_print 'VERBOSE' "File: '${BASH_SOURCE[0]}' Line: '${LINENO}'"


### PR DESCRIPTION
Use bash directly to truncate as alpine linux does not have a '--size' option in it's truncate command.